### PR TITLE
Authorization Code generation in Authorization Endpoint Filter

### DIFF
--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
@@ -29,10 +29,10 @@ public class OAuth2Authorization {
 	private String principalName;
 	private OAuth2AccessToken accessToken;
 	private Map<String, Object> attributes;
-	
+
 	public static final String ISSUED_AT = "issuedAt";
 	public static final String CODE_USED = "codeUsed";
-	
+
 	public String getRegisteredClientId() {
 		return registeredClientId;
 	}
@@ -48,27 +48,27 @@ public class OAuth2Authorization {
 	public static Builder createBuilder() {
 		return new Builder();
 	}
-	
+
 	public static class Builder {
 		private String registeredClientId;
 		private String principalName;
 		private OAuth2AccessToken accessToken;
 		private Map<String, Object> attributes;
-		
+
 		private Builder() {
-			this.attributes = new HashMap<String,Object>();
+			this.attributes = new HashMap<String, Object>();
 		}
-		
+
 		public Builder clientId(String clientId) {
 			this.registeredClientId = clientId;
 			return this;
 		}
-		
+
 		public Builder principalName(String principalName) {
 			this.principalName = principalName;
 			return this;
 		}
-		
+
 		public Builder accessToken(OAuth2AccessToken accessToken) {
 			this.accessToken = accessToken;
 			return this;
@@ -77,14 +77,14 @@ public class OAuth2Authorization {
 			this.attributes.put(key, value);
 			return this;
 		}
-		
+
 		public OAuth2Authorization build() {
 			OAuth2Authorization authorization = new OAuth2Authorization();
 			authorization.registeredClientId = this.registeredClientId;
 			authorization.principalName = this.principalName;
 			authorization.accessToken = this.accessToken;
 			authorization.attributes = this.attributes;
-			
+
 			return authorization;
 		}
 	}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
@@ -17,15 +17,73 @@ package org.springframework.security.oauth2.server.authorization;
 
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * @author Joe Grandja
+ * @author Paurav Munshi
  */
 public class OAuth2Authorization {
 	private String registeredClientId;
 	private String principalName;
 	private OAuth2AccessToken accessToken;
 	private Map<String, Object> attributes;
+	
+	public String getRegisteredClientId() {
+		return registeredClientId;
+	}
+	public String getPrincipalName() {
+		return principalName;
+	}
+	public OAuth2AccessToken getAccessToken() {
+		return accessToken;
+	}
+	public Object getAttribute(String attributeKey) {
+		return attributes.get(attributeKey);
+	}
+	public static Builder createBuilder() {
+		return new Builder();
+	}
+	
+	public static class Builder {
+		private String registeredClientId;
+		private String principalName;
+		private OAuth2AccessToken accessToken;
+		private Map<String, Object> attributes;
+		
+		private Builder() {
+			this.attributes = new HashMap<String,Object>();
+		}
+		
+		public Builder clientId(String clientId) {
+			this.registeredClientId = clientId;
+			return this;
+		}
+		
+		public Builder principalName(String principalName) {
+			this.principalName = principalName;
+			return this;
+		}
+		
+		public Builder accessToken(OAuth2AccessToken accessToken) {
+			this.accessToken = accessToken;
+			return this;
+		}
+		public Builder addAttribute(String key, Object value) {
+			this.attributes.put(key, value);
+			return this;
+		}
+		
+		public OAuth2Authorization build() {
+			OAuth2Authorization authorization = new OAuth2Authorization();
+			authorization.registeredClientId = this.registeredClientId;
+			authorization.principalName = this.principalName;
+			authorization.accessToken = this.accessToken;
+			authorization.attributes = this.attributes;
+			
+			return authorization;
+		}
+	}
 
 }

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
@@ -30,6 +30,9 @@ public class OAuth2Authorization {
 	private OAuth2AccessToken accessToken;
 	private Map<String, Object> attributes;
 	
+	public static final String ISSUED_AT = "issuedAt";
+	public static final String CODE_USED = "codeUsed";
+	
 	public String getRegisteredClientId() {
 		return registeredClientId;
 	}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/AuthorizationCodeKeyGenerator.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/AuthorizationCodeKeyGenerator.java
@@ -1,0 +1,19 @@
+package org.springframework.security.oauth2.server.authorization.util;
+
+import java.util.UUID;
+
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+
+/**
+ * @author Paurav Munshi
+ * @since 0.0.1
+ */
+public class AuthorizationCodeKeyGenerator implements StringKeyGenerator {
+
+	@Override
+	public String generateKey() {
+		// TODO Auto-generated method stub
+		return UUID.randomUUID().toString();
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/AuthorizationCodeKeyGenerator.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/AuthorizationCodeKeyGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.oauth2.server.authorization.util;
 
 import java.util.UUID;

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/OAuth2AuthorizationServerMessages.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/OAuth2AuthorizationServerMessages.java
@@ -1,0 +1,16 @@
+package org.springframework.security.oauth2.server.authorization.util;
+
+/**
+ * @author Paurav Munshi
+ * @since 0.0.1
+ */
+public final class OAuth2AuthorizationServerMessages {
+
+	public static final String REQUEST_MISSING_CLIENT_ID = "Request does not contain client id parameter";
+	public static final String CLIENT_ID_UNAUTHORIZED_FOR_CODE = "The provided client is not authorized to request authorization code";
+	public static final String RESPONSE_TYPE_MISSING_OR_INVALID = "Response type should be present and it should be 'code'";
+	public static final String CLIENT_ID_NOT_FOUND = "Can't validate the client id provided with the request";
+	public static final String USER_NOT_AUTHENTICATED = "User must be authenticated to perform this action";
+	public static final String REDIRECT_URI_MANDATORY_FOR_CLIENT = "Client is configured with multiple URIs. So a specific redirect uri must be supplied with request";
+
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/OAuth2AuthorizationServerMessages.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/util/OAuth2AuthorizationServerMessages.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.oauth2.server.authorization.util;
 
 /**

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilter.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilter.java
@@ -16,8 +16,6 @@
 package org.springframework.security.oauth2.server.authorization.web;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,6 +28,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.keygen.StringKeyGenerator;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
@@ -42,25 +42,47 @@ import org.springframework.security.oauth2.server.authorization.OAuth2Authorizat
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.util.AuthorizationCodeKeyGenerator;
+import org.springframework.security.oauth2.server.authorization.util.OAuth2AuthorizationServerMessages;
+import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Joe Grandja
  * @author Paurav Munshi
+ * @since 0.0.1
  */
 public class OAuth2AuthorizationEndpointFilter extends OncePerRequestFilter {
+	
 	private Converter<HttpServletRequest, OAuth2AuthorizationRequest> authorizationRequestConverter;
 	private RegisteredClientRepository registeredClientRepository;
 	private OAuth2AuthorizationService authorizationService;
 	private StringKeyGenerator codeGenerator;
 	private RedirectStrategy authorizationRedirectStrategy;
+	private RequestMatcher authorizationEndpiontMatcher;
 	
-	private static final OAuth2Error CLIENT_ID_ABSENT_ERROR = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST,"Request does not contain client id parameter",null);
-	private static final OAuth2Error CLIENT_ID_NOT_FOUND_ERROR = new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED,"Can't validate the client id provided with the request",null);
-	private static final OAuth2Error RESPONSE_TYPE_NOT_FOUND_ERROR = new OAuth2Error(OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE,"Response type should be present and it should be 'code'",null);
-	private static final OAuth2Error AUTHZ_CODE_NOT_SUPPORTED_ERROR = new OAuth2Error(OAuth2ErrorCodes.UNAUTHORIZED_CLIENT,"The provided client is not authorized to request authorization code",null);
+	private static final String DEFAULT_ENDPOINT = "/oauth2/authorize"; 
+	
+	private static final OAuth2Error CLIENT_ID_ABSENT_ERROR = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST, OAuth2AuthorizationServerMessages.REQUEST_MISSING_CLIENT_ID,null);
+	private static final OAuth2Error REDIRECT_URI_REQUIRED = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST, OAuth2AuthorizationServerMessages.REDIRECT_URI_MANDATORY_FOR_CLIENT,null);
+	private static final OAuth2Error CLIENT_ID_NOT_FOUND_ERROR = new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED, OAuth2AuthorizationServerMessages.CLIENT_ID_NOT_FOUND,null);
+	private static final OAuth2Error USER_NOT_AUTHENTICATED_ERROR = new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED, OAuth2AuthorizationServerMessages.USER_NOT_AUTHENTICATED,null);
+	private static final OAuth2Error AUTHZ_CODE_NOT_SUPPORTED_ERROR = new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED, OAuth2AuthorizationServerMessages.CLIENT_ID_UNAUTHORIZED_FOR_CODE,null);
+	private static final OAuth2Error RESPONSE_TYPE_NOT_FOUND_ERROR = new OAuth2Error(OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE, OAuth2AuthorizationServerMessages.RESPONSE_TYPE_MISSING_OR_INVALID,null);
+	
+	
+	
+	public OAuth2AuthorizationEndpointFilter() {
+		authorizationEndpiontMatcher = new AntPathRequestMatcher(DEFAULT_ENDPOINT);
+		authorizationRequestConverter  = new OAuth2AuthorizationRequestConverter();
+		codeGenerator  = new AuthorizationCodeKeyGenerator();
+		authorizationRedirectStrategy  = new DefaultRedirectStrategy();
+	}
 	
 	@Override
 	protected void doFilterInternal(HttpServletRequest request,
@@ -72,28 +94,40 @@ public class OAuth2AuthorizationEndpointFilter extends OncePerRequestFilter {
 		OAuth2Authorization authorization = null;
 		
 		try {
+			checkUserAuthenticated();
 			client = fetchRegisteredClient(request);
 			
 			authorizationRequest = authorizationRequestConverter.convert(request);
-			validateAuthorizationRequest(authorizationRequest,client);
+			validateAuthorizationRequest(request, client);
 			
 			String code = codeGenerator.generateKey();
 			authorization = buildOAuth2Authorization(client,authorizationRequest,code);
 			authorizationService.save(authorization);
 			
-			sendCodeOnSuccess(request, response, authorizationRequest, code);
+			String redirectUri = getRedirectUri(authorizationRequest,client);
+			sendCodeOnSuccess(request, response, authorizationRequest, redirectUri, code);
 		}catch(OAuth2AuthorizationException authorizationException) {
 			OAuth2Error authorizationError = authorizationException.getError();
 			
 			if(authorizationError.getErrorCode().equals(OAuth2ErrorCodes.INVALID_REQUEST)
-					|| authorizationError.getErrorCode().equals(OAuth2ErrorCodes.ACCESS_DENIED))
+					|| authorizationError.getErrorCode().equals(OAuth2ErrorCodes.ACCESS_DENIED)) {
 				sendErrorInResponse(response, authorizationError);
-			
-			if(authorizationError.getErrorCode().equals(OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE)
-					|| authorizationError.getErrorCode().equals(OAuth2ErrorCodes.UNAUTHORIZED_CLIENT))
-				sendErrorInRedirect(request, response, authorizationRequest, authorizationError, authorizationRequest.getRedirectUri());
+			}
+			else if(authorizationError.getErrorCode().equals(OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE)
+					|| authorizationError.getErrorCode().equals(OAuth2ErrorCodes.UNAUTHORIZED_CLIENT)) {
+				String redirectUri = getRedirectUri(authorizationRequest,client);
+				sendErrorInRedirect(request, response, authorizationRequest, authorizationError, redirectUri);
+			}else {
+				throw new ServletException(authorizationException);
+			}
 		}
 
+	}
+	
+	protected void checkUserAuthenticated() {
+		Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+		if(currentAuth==null || !currentAuth.isAuthenticated())
+			throw new OAuth2AuthorizationException(USER_NOT_AUTHENTICATED_ERROR);
 	}
 	
 	protected RegisteredClient fetchRegisteredClient(HttpServletRequest request) throws OAuth2AuthorizationException {
@@ -129,48 +163,64 @@ public class OAuth2AuthorizationEndpointFilter extends OncePerRequestFilter {
 	}
 	
 	
-	protected void validateAuthorizationRequest(OAuth2AuthorizationRequest authzRequest, RegisteredClient client) {
-		OAuth2AuthorizationResponseType responseType = Optional.ofNullable(authzRequest.getResponseType())
-						.orElseThrow(() -> new OAuth2AuthorizationException(RESPONSE_TYPE_NOT_FOUND_ERROR));
+	protected void validateAuthorizationRequest(HttpServletRequest request, RegisteredClient client) {
+		String responseType = request.getParameter(OAuth2ParameterNames.RESPONSE_TYPE);
+		if(StringUtils.isEmpty(responseType)
+				|| !responseType.equals(OAuth2AuthorizationResponseType.CODE.getValue()))
+			throw new OAuth2AuthorizationException(RESPONSE_TYPE_NOT_FOUND_ERROR);	
 		
-		if(!responseType.equals(OAuth2AuthorizationResponseType.CODE))
-			throw new OAuth2AuthorizationException(RESPONSE_TYPE_NOT_FOUND_ERROR);
-			
+		String redirectUri = request.getParameter(OAuth2ParameterNames.REDIRECT_URI);
+		if(StringUtils.isEmpty(redirectUri) && client.getRedirectUris().size() > 1)
+			throw new OAuth2AuthorizationException(REDIRECT_URI_REQUIRED);
+	}
+	
+	private String getRedirectUri(OAuth2AuthorizationRequest authorizationRequest, RegisteredClient client) {
+		return !StringUtils.isEmpty(authorizationRequest.getRedirectUri()) 
+		? authorizationRequest.getRedirectUri() 
+		: client.getRedirectUris().stream().findFirst().get();
 	}
 	
 	private void sendCodeOnSuccess(HttpServletRequest request, HttpServletResponse response,
-			OAuth2AuthorizationRequest authorizationRequest, String code) throws IOException {
-		StringBuilder urlBuilder = new StringBuilder(authorizationRequest.getRedirectUri())
-				.append(authorizationRequest.getRedirectUri().contains("?") ? "&" : "?")
-				.append(OAuth2ParameterNames.CODE).append("=").append(code);
+			OAuth2AuthorizationRequest authorizationRequest, String redirectUri, String code) throws IOException {
+		UriComponentsBuilder redirectUriBuilder = UriComponentsBuilder.fromUriString(redirectUri)
+				.queryParam(OAuth2ParameterNames.CODE, code);
 		if(!StringUtils.isEmpty(authorizationRequest.getState()))
-				urlBuilder.append("?").append("state=").append(authorizationRequest.getState());
+			redirectUriBuilder.queryParam(OAuth2ParameterNames.STATE, authorizationRequest.getState());
 		
-		String redirectUri = urlBuilder.toString();
-		this.authorizationRedirectStrategy.sendRedirect(request, response, redirectUri);
+		String finalRedirectUri = redirectUriBuilder.toUriString();
+		this.authorizationRedirectStrategy.sendRedirect(request, response, finalRedirectUri);
 	}
 	
 	private void sendErrorInResponse(HttpServletResponse response, OAuth2Error authorizationError) throws IOException {
-		response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), authorizationError.getErrorCode()+":"+authorizationError.getDescription());
+		int errorStatus = -1;
+		String errorCode = authorizationError.getErrorCode();
+		if(errorCode.equals(OAuth2ErrorCodes.ACCESS_DENIED))
+			errorStatus=HttpStatus.FORBIDDEN.value();
+		else errorStatus=HttpStatus.INTERNAL_SERVER_ERROR.value();
+		response.sendError(errorStatus, authorizationError.getErrorCode()+":"+authorizationError.getDescription());
 	}
 	
 	private void sendErrorInRedirect(HttpServletRequest request, HttpServletResponse response,
 			OAuth2AuthorizationRequest authorizationRequest,OAuth2Error authorizationError, 
 			String redirectUri) throws IOException {
-		StringBuilder urlBuilder = new StringBuilder(redirectUri)
-				.append(redirectUri.contains("?") ? "&" : "?")
-				.append("error_code=").append(authorizationError.getErrorCode())
-				.append("&").append("error_description=").append(authorizationError.getDescription());
+		UriComponentsBuilder redirectUriBuilder = UriComponentsBuilder.fromUriString(redirectUri)
+				.queryParam(OAuth2ParameterNames.ERROR, authorizationError.getErrorCode())
+				.queryParam(OAuth2ParameterNames.ERROR_DESCRIPTION, authorizationError.getDescription());
 		
 		if(!StringUtils.isEmpty(authorizationRequest.getState()))
-			urlBuilder.append("?").append("state=").append(authorizationRequest.getState());
+			redirectUriBuilder.queryParam(OAuth2ParameterNames.STATE, authorizationRequest.getState());
 				
-		String finalRedirectURI = urlBuilder.toString();
+		String finalRedirectURI = redirectUriBuilder.toUriString();
 		this.authorizationRedirectStrategy.sendRedirect(request, response, finalRedirectURI);
 	}
-
+	
 	public Converter<HttpServletRequest, OAuth2AuthorizationRequest> getAuthorizationRequestConverter() {
 		return authorizationRequestConverter;
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+		return !authorizationEndpiontMatcher.matches(request);
 	}
 
 	public void setAuthorizationRequestConverter(

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilter.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilter.java
@@ -15,33 +15,173 @@
  */
 package org.springframework.security.oauth2.server.authorization.web;
 
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.security.crypto.keygen.StringKeyGenerator;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
-import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
-import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponseType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * @author Joe Grandja
+ * @author Paurav Munshi
  */
 public class OAuth2AuthorizationEndpointFilter extends OncePerRequestFilter {
 	private Converter<HttpServletRequest, OAuth2AuthorizationRequest> authorizationRequestConverter;
 	private RegisteredClientRepository registeredClientRepository;
 	private OAuth2AuthorizationService authorizationService;
 	private StringKeyGenerator codeGenerator;
-
+	private RedirectStrategy authorizationRedirectStrategy;
+	
+	private static final OAuth2Error CLIENT_ID_ABSENT_ERROR = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST,"Request does not contain client id parameter",null);
+	private static final OAuth2Error CLIENT_ID_NOT_FOUND_ERROR = new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED,"Can't validate the client id provided with the request",null);
+	private static final OAuth2Error RESPONSE_TYPE_NOT_FOUND_ERROR = new OAuth2Error(OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE,"Response type should be present and it should be 'code'",null);
+	private static final OAuth2Error AUTHZ_CODE_NOT_SUPPORTED_ERROR = new OAuth2Error(OAuth2ErrorCodes.UNSUPPORTED_GRANT_TYPE,"The provided client does not support Authorization Code grant",null);
+	
 	@Override
 	protected void doFilterInternal(HttpServletRequest request,
 			HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
+		
+		RegisteredClient client = null;
+		OAuth2AuthorizationRequest authorizationRequest = null;
+		OAuth2Authorization authorization = null;
+		
+		try {
+			client = fetchRegisteredClient(request);
+			
+			authorizationRequest = authorizationRequestConverter.convert(request);
+			validateAuthorizationRequest(authorizationRequest,client);
+			
+			String code = codeGenerator.generateKey();
+			authorization = buildOAuth2Authorization(client,authorizationRequest,code);
+			authorizationService.save(authorization);
+			
+			this.authorizationRedirectStrategy.sendRedirect(request, response, authorizationRequest.getRedirectUri());
+		}catch(OAuth2AuthorizationException authorizationException) {
+			OAuth2Error authorizationError = authorizationException.getError();
+			
+			if(authorizationError.getErrorCode().equals(OAuth2ErrorCodes.INVALID_REQUEST)
+					|| authorizationError.getErrorCode().equals(OAuth2ErrorCodes.ACCESS_DENIED)
+					|| authorizationError.getErrorCode().equals(OAuth2ErrorCodes.UNSUPPORTED_GRANT_TYPE))
+				sendErrorInResponse(response, authorizationError);
+			
+			if(authorizationError.getErrorCode().equals(OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE))
+				sendErrorInRedirect(request, response, authorizationError, authorizationRequest.getRedirectUri());
+		}
 
 	}
+	
+	private RegisteredClient fetchRegisteredClient(HttpServletRequest request) throws OAuth2AuthorizationException {
+		String clientId = request.getParameter(OAuth2ParameterNames.CLIENT_ID);
+		if(StringUtils.isEmpty(clientId))
+			throw new OAuth2AuthorizationException(CLIENT_ID_ABSENT_ERROR);
+		
+		RegisteredClient client = registeredClientRepository.findByClientId(clientId);
+		if(client==null) 
+			throw new OAuth2AuthorizationException(CLIENT_ID_NOT_FOUND_ERROR);
+		
+		boolean isAuthoirzationGrantAllowed = Stream.of(client.getAuthorizationGrantTypes())
+				.anyMatch(grantType -> grantType.equals(AuthorizationGrantType.AUTHORIZATION_CODE));
+			if(!isAuthoirzationGrantAllowed)
+				throw new OAuth2AuthorizationException(AUTHZ_CODE_NOT_SUPPORTED_ERROR);
+			
+		return client;
+		
+	}
+	
+	private OAuth2Authorization buildOAuth2Authorization(RegisteredClient client, 
+			OAuth2AuthorizationRequest authorizationRequest, String code) {
+		OAuth2Authorization authorization = OAuth2Authorization.createBuilder()
+					.clientId(authorizationRequest.getClientId())
+					.addAttribute(OAuth2ParameterNames.CODE, code)
+					.build();
+		
+		return authorization;
+	}
+	
+	
+	private void validateAuthorizationRequest(OAuth2AuthorizationRequest authzRequest, RegisteredClient client) {
+		OAuth2AuthorizationResponseType responseType = Optional.ofNullable(authzRequest.getResponseType())
+						.orElseThrow(() -> new OAuth2AuthorizationException(RESPONSE_TYPE_NOT_FOUND_ERROR));
+		
+		if(!responseType.equals(OAuth2AuthorizationResponseType.CODE))
+			throw new OAuth2AuthorizationException(RESPONSE_TYPE_NOT_FOUND_ERROR);
+			
+	}
+	
+	private void sendErrorInResponse(HttpServletResponse response, OAuth2Error authorizationError) throws IOException {
+		response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), authorizationError.getErrorCode()+":"+authorizationError.getDescription());
+	}
+	
+	private void sendErrorInRedirect(HttpServletRequest request, HttpServletResponse response, OAuth2Error authorizationError, String redirectUri) throws IOException {
+		String finalRedirectURI = new StringBuilder(redirectUri)
+				.append("?").append("error_code=").append(authorizationError.getErrorCode())
+				.append("&").append("error_description=").append(authorizationError.getDescription())
+				.toString();
+		
+		this.authorizationRedirectStrategy.sendRedirect(request, response, finalRedirectURI);
+	}
 
+	public Converter<HttpServletRequest, OAuth2AuthorizationRequest> getAuthorizationRequestConverter() {
+		return authorizationRequestConverter;
+	}
+
+	public void setAuthorizationRequestConverter(
+			Converter<HttpServletRequest, OAuth2AuthorizationRequest> authorizationRequestConverter) {
+		this.authorizationRequestConverter = authorizationRequestConverter;
+	}
+
+	public RegisteredClientRepository getRegisteredClientRepository() {
+		return registeredClientRepository;
+	}
+
+	public void setRegisteredClientRepository(RegisteredClientRepository registeredClientRepository) {
+		this.registeredClientRepository = registeredClientRepository;
+	}
+
+	public OAuth2AuthorizationService getAuthorizationService() {
+		return authorizationService;
+	}
+
+	public void setAuthorizationService(OAuth2AuthorizationService authorizationService) {
+		this.authorizationService = authorizationService;
+	}
+
+	public StringKeyGenerator getCodeGenerator() {
+		return codeGenerator;
+	}
+
+	public void setCodeGenerator(StringKeyGenerator codeGenerator) {
+		this.codeGenerator = codeGenerator;
+	}
+
+	public RedirectStrategy getAuthorizationRedirectStrategy() {
+		return authorizationRedirectStrategy;
+	}
+	
+	public void getAuthorizationRedirectStrategy(RedirectStrategy redirectStrategy) {
+		this.authorizationRedirectStrategy = redirectStrategy;
+	}
+	
 }

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationRequestConverter.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationRequestConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.oauth2.server.authorization.web;
 
 import java.util.Arrays;
@@ -25,7 +40,7 @@ public class OAuth2AuthorizationRequestConverter implements Converter<HttpServle
 		Set<String> scopes = !StringUtils.isEmpty(scope)
 				? new LinkedHashSet<String>(Arrays.asList(scope.split(" ")))
 				: Collections.emptySet();
-				
+
 		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
 				.clientId(request.getParameter(OAuth2ParameterNames.CLIENT_ID))
 				.redirectUri(request.getParameter(OAuth2ParameterNames.REDIRECT_URI))
@@ -33,7 +48,7 @@ public class OAuth2AuthorizationRequestConverter implements Converter<HttpServle
 				.state(request.getParameter(OAuth2ParameterNames.STATE))
 				.authorizationUri(request.getServletPath())
 				.build();
-				
+
 		return authorizationRequest;
 	}
 

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationRequestConverter.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationRequestConverter.java
@@ -1,0 +1,40 @@
+package org.springframework.security.oauth2.server.authorization.web;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Paurav Munshi
+ * @since 0.0.1
+ * @see Converter
+ */
+public class OAuth2AuthorizationRequestConverter implements Converter<HttpServletRequest, OAuth2AuthorizationRequest>{
+
+	@Override
+	public OAuth2AuthorizationRequest convert(HttpServletRequest request) {
+		String scope = request.getParameter(OAuth2ParameterNames.SCOPE);
+		Set<String> scopes = !StringUtils.isEmpty(scope)
+				? new LinkedHashSet<String>(Arrays.asList(scope.split(" ")))
+				: Collections.emptySet();
+				
+		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
+				.clientId(request.getParameter(OAuth2ParameterNames.CLIENT_ID))
+				.redirectUri(request.getParameter(OAuth2ParameterNames.REDIRECT_URI))
+				.scopes(scopes)
+				.state(request.getParameter(OAuth2ParameterNames.STATE))
+				.authorizationUri(request.getServletPath())
+				.build();
+				
+		return authorizationRequest;
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
+++ b/core/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
@@ -58,7 +58,7 @@ public class TestRegisteredClients {
 				.scope("profile")
 				.scope("email");
 	}
-	
+
 	public static RegisteredClient.Builder validAuthorizationGrantClientMultiRedirectUris() {
 		return RegisteredClient.withId("valid_client_multi_uri_id")
 				.clientId("valid_client_multi_uri")
@@ -71,7 +71,7 @@ public class TestRegisteredClients {
 				.scope("profile")
 				.scope("email");
 	}
-	
+
 	public static RegisteredClient.Builder validClientCredentialsGrantRegisteredClient() {
 		return RegisteredClient.withId("valid_cc_client_id")
 				.clientId("valid_cc_client")

--- a/core/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
+++ b/core/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
@@ -46,4 +46,40 @@ public class TestRegisteredClients {
 				.scope("profile")
 				.scope("email");
 	}
+
+	public static RegisteredClient.Builder validAuthorizationGrantRegisteredClient() {
+		return RegisteredClient.withId("valid_client_id")
+				.clientId("valid_client")
+				.clientSecret("valid_secret")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.BASIC)
+				.redirectUri("http://localhost:8080/test-application/callback")
+				.scope("openid")
+				.scope("profile")
+				.scope("email");
+	}
+	
+	public static RegisteredClient.Builder validAuthorizationGrantClientMultiRedirectUris() {
+		return RegisteredClient.withId("valid_client_multi_uri_id")
+				.clientId("valid_client_multi_uri")
+				.clientSecret("valid_secret")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.BASIC)
+				.redirectUri("http://localhost:8080/test-application/callback")
+				.redirectUri("http://localhost:8080/another-test-application/callback")
+				.scope("openid")
+				.scope("profile")
+				.scope("email");
+	}
+	
+	public static RegisteredClient.Builder validClientCredentialsGrantRegisteredClient() {
+		return RegisteredClient.withId("valid_cc_client_id")
+				.clientId("valid_cc_client")
+				.clientSecret("valid_secret")
+				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.BASIC)
+				.scope("openid")
+				.scope("profile")
+				.scope("email");
+	}
 }

--- a/core/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTest.java
+++ b/core/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTest.java
@@ -1,20 +1,37 @@
 package org.springframework.security.oauth2.server.authorization.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
+import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
-import org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter;
+import org.springframework.security.oauth2.server.authorization.client.TestRegisteredClients;
+import org.springframework.security.oauth2.server.authorization.util.OAuth2AuthorizationServerMessages;
 import org.springframework.security.web.RedirectStrategy;
 
 
@@ -22,10 +39,15 @@ import org.springframework.security.web.RedirectStrategy;
  * Tests for {@link OAuth2AuthorizationEndpointFilter}.
  *
  * @author Paurav Munshi
+ * @since 0.0.1
  */
 
 public class OAuth2AuthorizationEndpointFilterTest {
 	
+	private static final String VALID_CLIENT = "valid_client";
+	private static final String VALID_CLIENT_MULTI_URI = "valid_client_multi_uri";
+	private static final String VALID_CC_CLIENT = "valid_cc_client";
+
 	private OAuth2AuthorizationEndpointFilter filter;
 	
 	private RedirectStrategy authorizationRedirectStrategy = mock(RedirectStrategy.class);
@@ -33,26 +55,258 @@ public class OAuth2AuthorizationEndpointFilterTest {
 	private OAuth2AuthorizationService authorizationService = mock(OAuth2AuthorizationService.class);
 	private StringKeyGenerator codeGenerator = mock(StringKeyGenerator.class);
 	private RegisteredClientRepository registeredClientRepository = mock(RegisteredClientRepository.class);
+	private Authentication authentication = mock(Authentication.class);
 	
 	@Before
 	public void setUp() {
 		filter = new OAuth2AuthorizationEndpointFilter();
 		
-		filter.setAuthorizationRequestConverter(authorizationConverter);
 		filter.setAuthorizationService(authorizationService);
 		filter.setCodeGenerator(codeGenerator);
 		filter.setRegisteredClientRepository(registeredClientRepository);
-		filter.setAuthorizationRedirectStrategy(authorizationRedirectStrategy);
+		
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+	
+	@Test
+	public void testFilterRedirectsWithCodeOnValidReq() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
+		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
+		when(codeGenerator.generateKey()).thenReturn("sample_code");
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository).findByClientId(VALID_CLIENT);
+		verify(authorizationService).save(any(OAuth2Authorization.class));
+		verify(codeGenerator).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
+		assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:8080/test-application/callback?code=sample_code&state=teststate");
+		
+	}
+	
+	@Test
+	public void testFilterRedirectsWithCodeToDefaultRedirectURIWhenNotPresentInRequest() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.REDIRECT_URI, "");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
+		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
+		when(codeGenerator.generateKey()).thenReturn("sample_code");
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository).findByClientId(VALID_CLIENT);
+		verify(authorizationService).save(any(OAuth2Authorization.class));
+		verify(codeGenerator).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
+		assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:8080/test-application/callback?code=sample_code&state=teststate");
+		
+	}
+	
+	@Test
+	public void testErrorWhenRedirectURINotPresentAndClientHasMulitipleUris() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.CLIENT_ID, VALID_CLIENT_MULTI_URI);
+		request.setParameter(OAuth2ParameterNames.REDIRECT_URI, "");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantClientMultiRedirectUris().build();
+		when(registeredClientRepository.findByClientId(VALID_CLIENT_MULTI_URI)).thenReturn(registeredClient);
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication, times(1)).isAuthenticated();
+		verify(registeredClientRepository, times(1)).findByClientId(VALID_CLIENT_MULTI_URI);
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST+":"+OAuth2AuthorizationServerMessages.REDIRECT_URI_MANDATORY_FOR_CLIENT);
+		
+	}
+	
+	@Test
+	public void testErrorClientIdNotSupportAuthorizationGrantFlow() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.CLIENT_ID, VALID_CC_CLIENT);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validClientCredentialsGrantRegisteredClient().build();
+		when(registeredClientRepository.findByClientId(VALID_CC_CLIENT)).thenReturn(registeredClient);
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication, times(1)).isAuthenticated();
+		verify(registeredClientRepository, times(1)).findByClientId(VALID_CC_CLIENT);
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.ACCESS_DENIED+":"+OAuth2AuthorizationServerMessages.CLIENT_ID_UNAUTHORIZED_FOR_CODE);
+		
+	}
+	
+	@Test
+	public void testErrorWhenClientIdMissinInRequest() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.CLIENT_ID, "");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository, times(0)).findByClientId(anyString());
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+		assertThat(response.getContentAsString()).isEmpty();
+		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST+":"+OAuth2AuthorizationServerMessages.REQUEST_MISSING_CLIENT_ID);
+		
+	}
+	
+	@Test
+	public void testErrorWhenUnregisteredClientInRequest() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.CLIENT_ID, "unregistered_client");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
+		when(registeredClientRepository.findByClientId("unregistered_client")).thenReturn(null);
+		when(codeGenerator.generateKey()).thenReturn("sample_code");
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository, times(1)).findByClientId("unregistered_client");
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+		assertThat(response.getContentAsString()).isEmpty();
+		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.ACCESS_DENIED+":"+OAuth2AuthorizationServerMessages.CLIENT_ID_NOT_FOUND);
+		
+	}
+	
+	@Test
+	public void testErrorWhenUnauthenticatedUserInRequest() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		when(authentication.isAuthenticated()).thenReturn(false);
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository, times(0)).findByClientId(anyString());
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+		assertThat(response.getContentAsString()).isEmpty();
+		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.ACCESS_DENIED+":"+OAuth2AuthorizationServerMessages.USER_NOT_AUTHENTICATED);
+		
+	}
+	
+	@Test
+	public void testShouldNotFilterForUnsupportedEndpoint() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setServletPath("/custom/authorize");
+		
+		boolean willFilterGetInvoked = !filter.shouldNotFilter(request);
+		
+		assertThat(willFilterGetInvoked).isEqualTo(false);
+		
+	}
+	
+	@Test
+	public void testErrorWhenResponseTypeNotPresent() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.RESPONSE_TYPE, "");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
+		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
+		when(codeGenerator.generateKey()).thenReturn("sample_code");
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository, times(1)).findByClientId(VALID_CLIENT);
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
+		assertThat(response.getRedirectedUrl()).startsWith(request.getParameter(OAuth2ParameterNames.REDIRECT_URI));
+		assertThat(response.getRedirectedUrl()).contains("error="+OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE);
+		assertThat(URLDecoder.decode(response.getRedirectedUrl(), StandardCharsets.UTF_8.toString())).contains("error_description="+OAuth2AuthorizationServerMessages.RESPONSE_TYPE_MISSING_OR_INVALID);
+		
+	}
+	
+	@Test
+	public void testErrorWhenResponseTypeIsUnsupported() throws Exception {
+		MockHttpServletRequest request = getValidMockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.RESPONSE_TYPE, "token");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		
+		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
+		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
+		when(codeGenerator.generateKey()).thenReturn("sample_code");
+		when(authentication.isAuthenticated()).thenReturn(true);
+		
+		
+		filter.doFilterInternal(request, response, filterChain);
+		
+		verify(authentication).isAuthenticated();
+		verify(registeredClientRepository, times(1)).findByClientId(VALID_CLIENT);
+		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
+		verify(codeGenerator, times(0)).generateKey();
+		
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
+		assertThat(response.getRedirectedUrl()).startsWith(request.getParameter(OAuth2ParameterNames.REDIRECT_URI));
+		assertThat(response.getRedirectedUrl()).contains("error="+OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE);
+		assertThat(URLDecoder.decode(response.getRedirectedUrl(), StandardCharsets.UTF_8.toString())).contains("error_description="+OAuth2AuthorizationServerMessages.RESPONSE_TYPE_MISSING_OR_INVALID);
+		
 	}
 
 	@Test
 	public void testSettersAreSettingProperValue() {
 		OAuth2AuthorizationEndpointFilter blankFilter = new OAuth2AuthorizationEndpointFilter();
 		
-		assertThat(blankFilter.getAuthorizationRedirectStrategy()).isNull();
-		assertThat(blankFilter.getAuthorizationRequestConverter()).isNull();
+		assertThat(blankFilter.getAuthorizationRedirectStrategy()).isNotEqualTo(authorizationRedirectStrategy);
+		assertThat(blankFilter.getAuthorizationRequestConverter()).isNotEqualTo(authorizationConverter);
 		assertThat(blankFilter.getAuthorizationService()).isNull();
-		assertThat(blankFilter.getCodeGenerator()).isNull();
+		assertThat(blankFilter.getCodeGenerator()).isNotEqualTo(codeGenerator);
 		assertThat(blankFilter.getRegisteredClientRepository()).isNull();
 		
 		blankFilter.setAuthorizationRequestConverter(authorizationConverter);
@@ -66,6 +320,22 @@ public class OAuth2AuthorizationEndpointFilterTest {
 		assertThat(blankFilter.getAuthorizationService()).isEqualTo(authorizationService);
 		assertThat(blankFilter.getCodeGenerator()).isEqualTo(codeGenerator);
 		assertThat(blankFilter.getRegisteredClientRepository()).isEqualTo(registeredClientRepository);
+	}
+	
+	
+	private MockHttpServletRequest getValidMockHttpServletRequest() {
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(OAuth2ParameterNames.CLIENT_ID, VALID_CLIENT);
+		request.setParameter(OAuth2ParameterNames.RESPONSE_TYPE, "code");
+		request.setParameter(OAuth2ParameterNames.SCOPE, "openid profile email");
+		request.setParameter(OAuth2ParameterNames.REDIRECT_URI, "http://localhost:8080/test-application/callback");
+		request.setParameter(OAuth2ParameterNames.STATE, "teststate");
+		request.setServletPath("/oauth2/authorize");
+		
+		return request;
+		
+		
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTest.java
+++ b/core/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.oauth2.server.authorization.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,80 +58,80 @@ import org.springframework.security.web.RedirectStrategy;
  */
 
 public class OAuth2AuthorizationEndpointFilterTest {
-	
+
 	private static final String VALID_CLIENT = "valid_client";
 	private static final String VALID_CLIENT_MULTI_URI = "valid_client_multi_uri";
 	private static final String VALID_CC_CLIENT = "valid_cc_client";
 
 	private OAuth2AuthorizationEndpointFilter filter;
-	
+
 	private RedirectStrategy authorizationRedirectStrategy = mock(RedirectStrategy.class);
 	private Converter<HttpServletRequest, OAuth2AuthorizationRequest> authorizationConverter = mock(Converter.class);
 	private OAuth2AuthorizationService authorizationService = mock(OAuth2AuthorizationService.class);
 	private StringKeyGenerator codeGenerator = mock(StringKeyGenerator.class);
 	private RegisteredClientRepository registeredClientRepository = mock(RegisteredClientRepository.class);
 	private Authentication authentication = mock(Authentication.class);
-	
+
 	@Before
 	public void setUp() {
 		filter = new OAuth2AuthorizationEndpointFilter();
-		
+
 		filter.setAuthorizationService(authorizationService);
 		filter.setCodeGenerator(codeGenerator);
 		filter.setRegisteredClientRepository(registeredClientRepository);
-		
+
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 	}
-	
+
 	@Test
 	public void testFilterRedirectsWithCodeOnValidReq() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
 		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
 		when(codeGenerator.generateKey()).thenReturn("sample_code");
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
-		
+
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository).findByClientId(VALID_CLIENT);
 		verify(authorizationService).save(any(OAuth2Authorization.class));
 		verify(codeGenerator).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
 		assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:8080/test-application/callback?code=sample_code&state=teststate");
-		
+
 	}
-	
+
 	@Test
 	public void testFilterRedirectsWithCodeToDefaultRedirectURIWhenNotPresentInRequest() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.REDIRECT_URI, "");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
 		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
 		when(codeGenerator.generateKey()).thenReturn("sample_code");
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
-		
+
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository).findByClientId(VALID_CLIENT);
 		verify(authorizationService).save(any(OAuth2Authorization.class));
 		verify(codeGenerator).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
 		assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:8080/test-application/callback?code=sample_code&state=teststate");
-		
+
 	}
-	
+
 	@Test
 	public void testErrorWhenRedirectURINotPresentAndClientHasMulitipleUris() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
@@ -124,207 +139,207 @@ public class OAuth2AuthorizationEndpointFilterTest {
 		request.setParameter(OAuth2ParameterNames.REDIRECT_URI, "");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantClientMultiRedirectUris().build();
 		when(registeredClientRepository.findByClientId(VALID_CLIENT_MULTI_URI)).thenReturn(registeredClient);
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
-		
+
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication, times(1)).isAuthenticated();
 		verify(registeredClientRepository, times(1)).findByClientId(VALID_CLIENT_MULTI_URI);
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
 		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST+":"+OAuth2AuthorizationServerMessages.REDIRECT_URI_MANDATORY_FOR_CLIENT);
-		
+
 	}
-	
+
 	@Test
 	public void testErrorClientIdNotSupportAuthorizationGrantFlow() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.CLIENT_ID, VALID_CC_CLIENT);
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validClientCredentialsGrantRegisteredClient().build();
 		when(registeredClientRepository.findByClientId(VALID_CC_CLIENT)).thenReturn(registeredClient);
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
-		
+
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication, times(1)).isAuthenticated();
 		verify(registeredClientRepository, times(1)).findByClientId(VALID_CC_CLIENT);
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
 		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.ACCESS_DENIED+":"+OAuth2AuthorizationServerMessages.CLIENT_ID_UNAUTHORIZED_FOR_CODE);
-		
+
 	}
-	
+
 	@Test
 	public void testErrorWhenClientIdMissinInRequest() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.CLIENT_ID, "");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository, times(0)).findByClientId(anyString());
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
 		assertThat(response.getContentAsString()).isEmpty();
 		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST+":"+OAuth2AuthorizationServerMessages.REQUEST_MISSING_CLIENT_ID);
-		
+
 	}
-	
+
 	@Test
 	public void testErrorWhenUnregisteredClientInRequest() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.CLIENT_ID, "unregistered_client");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
 		when(registeredClientRepository.findByClientId("unregistered_client")).thenReturn(null);
 		when(codeGenerator.generateKey()).thenReturn("sample_code");
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository, times(1)).findByClientId("unregistered_client");
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
 		assertThat(response.getContentAsString()).isEmpty();
 		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.ACCESS_DENIED+":"+OAuth2AuthorizationServerMessages.CLIENT_ID_NOT_FOUND);
-		
+
 	}
-	
+
 	@Test
 	public void testErrorWhenUnauthenticatedUserInRequest() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		when(authentication.isAuthenticated()).thenReturn(false);
-		
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository, times(0)).findByClientId(anyString());
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
 		assertThat(response.getContentAsString()).isEmpty();
 		assertThat(response.getErrorMessage()).isEqualTo(OAuth2ErrorCodes.ACCESS_DENIED+":"+OAuth2AuthorizationServerMessages.USER_NOT_AUTHENTICATED);
-		
+
 	}
-	
+
 	@Test
 	public void testShouldNotFilterForUnsupportedEndpoint() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setServletPath("/custom/authorize");
-		
+
 		boolean willFilterGetInvoked = !filter.shouldNotFilter(request);
-		
+
 		assertThat(willFilterGetInvoked).isEqualTo(false);
-		
+
 	}
-	
+
 	@Test
 	public void testErrorWhenResponseTypeNotPresent() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.RESPONSE_TYPE, "");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
 		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
 		when(codeGenerator.generateKey()).thenReturn("sample_code");
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
-		
+
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository, times(1)).findByClientId(VALID_CLIENT);
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
 		assertThat(response.getRedirectedUrl()).startsWith(request.getParameter(OAuth2ParameterNames.REDIRECT_URI));
 		assertThat(response.getRedirectedUrl()).contains("error="+OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE);
 		assertThat(URLDecoder.decode(response.getRedirectedUrl(), StandardCharsets.UTF_8.toString())).contains("error_description="+OAuth2AuthorizationServerMessages.RESPONSE_TYPE_MISSING_OR_INVALID);
-		
+
 	}
-	
+
 	@Test
 	public void testErrorWhenResponseTypeIsUnsupported() throws Exception {
 		MockHttpServletRequest request = getValidMockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.RESPONSE_TYPE, "token");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		FilterChain filterChain = mock(FilterChain.class);
-		
+
 		RegisteredClient registeredClient = TestRegisteredClients.validAuthorizationGrantRegisteredClient().build();
 		when(registeredClientRepository.findByClientId(VALID_CLIENT)).thenReturn(registeredClient);
 		when(codeGenerator.generateKey()).thenReturn("sample_code");
 		when(authentication.isAuthenticated()).thenReturn(true);
-		
-		
+
+
 		filter.doFilterInternal(request, response, filterChain);
-		
+
 		verify(authentication).isAuthenticated();
 		verify(registeredClientRepository, times(1)).findByClientId(VALID_CLIENT);
 		verify(authorizationService, times(0)).save(any(OAuth2Authorization.class));
 		verify(codeGenerator, times(0)).generateKey();
-		
+
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
 		assertThat(response.getRedirectedUrl()).startsWith(request.getParameter(OAuth2ParameterNames.REDIRECT_URI));
 		assertThat(response.getRedirectedUrl()).contains("error="+OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE);
 		assertThat(URLDecoder.decode(response.getRedirectedUrl(), StandardCharsets.UTF_8.toString())).contains("error_description="+OAuth2AuthorizationServerMessages.RESPONSE_TYPE_MISSING_OR_INVALID);
-		
+
 	}
 
 	@Test
 	public void testSettersAreSettingProperValue() {
 		OAuth2AuthorizationEndpointFilter blankFilter = new OAuth2AuthorizationEndpointFilter();
-		
+
 		assertThat(blankFilter.getAuthorizationRedirectStrategy()).isNotEqualTo(authorizationRedirectStrategy);
 		assertThat(blankFilter.getAuthorizationRequestConverter()).isNotEqualTo(authorizationConverter);
 		assertThat(blankFilter.getAuthorizationService()).isNull();
 		assertThat(blankFilter.getCodeGenerator()).isNotEqualTo(codeGenerator);
 		assertThat(blankFilter.getRegisteredClientRepository()).isNull();
-		
+
 		blankFilter.setAuthorizationRequestConverter(authorizationConverter);
 		blankFilter.setAuthorizationService(authorizationService);
 		blankFilter.setCodeGenerator(codeGenerator);
 		blankFilter.setRegisteredClientRepository(registeredClientRepository);
 		blankFilter.setAuthorizationRedirectStrategy(authorizationRedirectStrategy);
-		
+
 		assertThat(blankFilter.getAuthorizationRedirectStrategy()).isEqualTo(authorizationRedirectStrategy);
 		assertThat(blankFilter.getAuthorizationRequestConverter()).isEqualTo(authorizationConverter);
 		assertThat(blankFilter.getAuthorizationService()).isEqualTo(authorizationService);
 		assertThat(blankFilter.getCodeGenerator()).isEqualTo(codeGenerator);
 		assertThat(blankFilter.getRegisteredClientRepository()).isEqualTo(registeredClientRepository);
 	}
-	
-	
+
+
 	private MockHttpServletRequest getValidMockHttpServletRequest() {
-		
+
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setParameter(OAuth2ParameterNames.CLIENT_ID, VALID_CLIENT);
 		request.setParameter(OAuth2ParameterNames.RESPONSE_TYPE, "code");
@@ -332,10 +347,10 @@ public class OAuth2AuthorizationEndpointFilterTest {
 		request.setParameter(OAuth2ParameterNames.REDIRECT_URI, "http://localhost:8080/test-application/callback");
 		request.setParameter(OAuth2ParameterNames.STATE, "teststate");
 		request.setServletPath("/oauth2/authorize");
-		
+
 		return request;
-		
-		
+
+
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTest.java
+++ b/core/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTest.java
@@ -1,0 +1,71 @@
+package org.springframework.security.oauth2.server.authorization.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.crypto.keygen.StringKeyGenerator;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.web.OAuth2AuthorizationEndpointFilter;
+import org.springframework.security.web.RedirectStrategy;
+
+
+/**
+ * Tests for {@link OAuth2AuthorizationEndpointFilter}.
+ *
+ * @author Paurav Munshi
+ */
+
+public class OAuth2AuthorizationEndpointFilterTest {
+	
+	private OAuth2AuthorizationEndpointFilter filter;
+	
+	private RedirectStrategy authorizationRedirectStrategy = mock(RedirectStrategy.class);
+	private Converter<HttpServletRequest, OAuth2AuthorizationRequest> authorizationConverter = mock(Converter.class);
+	private OAuth2AuthorizationService authorizationService = mock(OAuth2AuthorizationService.class);
+	private StringKeyGenerator codeGenerator = mock(StringKeyGenerator.class);
+	private RegisteredClientRepository registeredClientRepository = mock(RegisteredClientRepository.class);
+	
+	@Before
+	public void setUp() {
+		filter = new OAuth2AuthorizationEndpointFilter();
+		
+		filter.setAuthorizationRequestConverter(authorizationConverter);
+		filter.setAuthorizationService(authorizationService);
+		filter.setCodeGenerator(codeGenerator);
+		filter.setRegisteredClientRepository(registeredClientRepository);
+		filter.setAuthorizationRedirectStrategy(authorizationRedirectStrategy);
+	}
+
+	@Test
+	public void testSettersAreSettingProperValue() {
+		OAuth2AuthorizationEndpointFilter blankFilter = new OAuth2AuthorizationEndpointFilter();
+		
+		assertThat(blankFilter.getAuthorizationRedirectStrategy()).isNull();
+		assertThat(blankFilter.getAuthorizationRequestConverter()).isNull();
+		assertThat(blankFilter.getAuthorizationService()).isNull();
+		assertThat(blankFilter.getCodeGenerator()).isNull();
+		assertThat(blankFilter.getRegisteredClientRepository()).isNull();
+		
+		blankFilter.setAuthorizationRequestConverter(authorizationConverter);
+		blankFilter.setAuthorizationService(authorizationService);
+		blankFilter.setCodeGenerator(codeGenerator);
+		blankFilter.setRegisteredClientRepository(registeredClientRepository);
+		blankFilter.setAuthorizationRedirectStrategy(authorizationRedirectStrategy);
+		
+		assertThat(blankFilter.getAuthorizationRedirectStrategy()).isEqualTo(authorizationRedirectStrategy);
+		assertThat(blankFilter.getAuthorizationRequestConverter()).isEqualTo(authorizationConverter);
+		assertThat(blankFilter.getAuthorizationService()).isEqualTo(authorizationService);
+		assertThat(blankFilter.getCodeGenerator()).isEqualTo(codeGenerator);
+		assertThat(blankFilter.getRegisteredClientRepository()).isEqualTo(registeredClientRepository);
+	}
+
+}

--- a/etc/checkstyle/checkstyle.xml
+++ b/etc/checkstyle/checkstyle.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+	<!-- Suppressions -->
+	<module name="SuppressionFilter">
+		<property name="file" value="${config_loc}/suppressions.xml"/>
+	</module>
+
+	<!-- Root Checks -->
+	<module name="RegexpHeader">
+		<property name="headerFile" value="${config_loc}/header.txt"/>
+		<property name="fileExtensions" value="java"/>
+	</module>
+
+	<!-- Root Checks -->
+	<module name="TreeWalker">
+		<!-- Annotations -->
+		<module name="MissingOverrideCheck" />
+
+		<!-- Coding -->
+		<module name="EmptyStatementCheck" />
+		<module name="RedundantModifier" />
+
+		<!-- Imports -->
+		<module name="UnusedImportsCheck">
+			<property name="processJavadoc" value="true" />
+		</module>
+
+		<!-- Regexp -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\t* +\t*\S"/>
+			<property name="message" value="Line has leading space characters; indentation should be performed with tabs only."/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="RegexpSinglelineJava">
+			<property name="maximum" value="0"/>
+			<property name="format" value="org\.junit\.Assert\.assert"/>
+			<property name="message" value="Please use AssertJ imports."/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="[ \t]+$"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Trailing whitespace"/>
+		</module>
+
+		<!-- Whitespace -->
+		<module name="WhitespaceAfterCheck" />
+	</module>
+</module>

--- a/etc/checkstyle/header.txt
+++ b/etc/checkstyle/header.txt
@@ -1,0 +1,16 @@
+^\Q/*\E$
+^\Q * Copyright\E (\d{4}(\-\d{4})? the original author or authors\.|(\d{4}, )*(\d{4}) Acegi Technology Pty Limited)$
+^\Q *\E$
+^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
+^\Q * you may not use this file except in compliance with the License.\E$
+^\Q * You may obtain a copy of the License at\E$
+^\Q *\E$
+^\Q *      https://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *\E$
+^\Q * Unless required by applicable law or agreed to in writing, software\E$
+^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$
+^\Q * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\E$
+^\Q * See the License for the specific language governing permissions and\E$
+^\Q * limitations under the License.\E$
+^\Q */\E$
+^.*$

--- a/etc/checkstyle/suppressions.xml
+++ b/etc/checkstyle/suppressions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+	<suppress files=".+Application\.java" checks="HideUtilityClassConstructor"/>
+	<suppress files=".+Configuration\.java" checks="HideUtilityClassConstructor"/>
+	<suppress files="[\\/]BCrypt(Tests)?\.java" checks="RegexpHeader"/>
+
+	<suppress files="[\\/]src[\\/]test[\\/]java[\\/]" checks="Javadoc"/>
+	<suppress files="[\\/]src[\\/]integration-test[\\/]java[\\/]" checks="Javadoc"/>
+
+	<suppress files="[\\/]docs[\\/]" checks="Javadoc"/>
+	<suppress files="[\\/]docs[\\/]" checks="CommentsIndentation"/>
+	<suppress files="[\\/]docs[\\/]" checks="InnerTypeLast"/>
+
+	<suppress files="[\\/]samples[\\/]" checks="Javadoc"/>
+	<suppress files="[\\/]samples[\\/]" checks="CommentsIndentation"/>
+	<suppress files="[\\/]samples[\\/]" checks="InnerTypeLast"/>
+</suppressions>

--- a/samples/boot/minimal/src/main/java/sample/MinimalAuthorizationServerApplication.java
+++ b/samples/boot/minimal/src/main/java/sample/MinimalAuthorizationServerApplication.java
@@ -21,7 +21,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class MinimalAuthorizationServerApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(MinimalAuthorizationServerApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(MinimalAuthorizationServerApplication.class, args);
+	}
+
 }

--- a/samples/boot/minimal/src/test/java/sample/MinimalAuthorizationServerApplicationTests.java
+++ b/samples/boot/minimal/src/test/java/sample/MinimalAuthorizationServerApplicationTests.java
@@ -24,8 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 public class MinimalAuthorizationServerApplicationTests {
 
-    @Test
-    public void loadContext(ApplicationContext context) {
-        assertThat(context).isNotNull();
-    }
+	@Test
+	public void loadContext(ApplicationContext context) {
+		assertThat(context).isNotNull();
+	}
+
 }

--- a/samples/boot/oauth2resourceserver/spring-authorization-server-samples-boot-oauth2resourceserver.gradle
+++ b/samples/boot/oauth2resourceserver/spring-authorization-server-samples-boot-oauth2resourceserver.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'io.spring.convention.spring-sample-boot'
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.security:spring-security-config'
+	implementation 'org.springframework.security:spring-security-oauth2-resource-server'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
+	testImplementation('org.springframework.boot:spring-boot-starter-test') {
+		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+	}
+}
+
+test {
+	useJUnitPlatform()
+}

--- a/samples/boot/oauth2resourceserver/src/main/java/sample/ResourceController.java
+++ b/samples/boot/oauth2resourceserver/src/main/java/sample/ResourceController.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ResourceController {
+
+	@GetMapping("/")
+	public String resource() {
+		return "resource";
+	}
+
+}

--- a/samples/boot/oauth2resourceserver/src/main/java/sample/ResourceServerApplication.java
+++ b/samples/boot/oauth2resourceserver/src/main/java/sample/ResourceServerApplication.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ResourceServerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ResourceServerApplication.class, args);
+	}
+}

--- a/samples/boot/oauth2resourceserver/src/main/resources/application.yml
+++ b/samples/boot/oauth2resourceserver/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: https://localhost:8090/oauth2/keys

--- a/samples/boot/oauth2resourceserver/src/test/java/sample/ResourceControllerTests.java
+++ b/samples/boot/oauth2resourceserver/src/test/java/sample/ResourceControllerTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ResourceControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	public void shouldReturnOkWithToken() throws Exception {
+		this.mockMvc.perform(get("/").header("Authorization", "Bearer TOKEN"))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	public void shouldReturnUnauthorizedWithoutToken() throws Exception {
+		this.mockMvc.perform(get("/"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@TestConfiguration
+	static class ResourceControllerTestConfiguration {
+		@Bean
+		public JwtDecoder jwtDecoder() {
+			return (token) -> {
+				Map<String, Object> headers = new HashMap<>();
+				headers.put("alg", "RS256");
+				headers.put("typ", "JWT");
+
+				Map<String, Object> claims = new HashMap<>();
+				claims.put("sub", "1234567");
+				claims.put("name", "John Doe");
+				return new Jwt(token, Instant.now(), Instant.now().plusMillis(5000), headers, claims);
+			};
+		}
+	}
+}


### PR DESCRIPTION
Fixes #66 

Functionality Covered
-------------------------
- Validation of client id & response type
- Generate authorization code
- Save Authorization
- Redirect to client redirect uri
- Send error in http response
- Send error as query params in redirect uri

Validations covered
-------------------
- Client Id should be mandatory
- Client Id should be registered
- Client Id should be configured with Authorization grant type
- Response type is mandaotry
- Response type should be code