### PR TITLE
Introduce JwtEncoder

### DIFF
--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/DefaultKeyManager.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/DefaultKeyManager.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import org.springframework.util.Assert;
+
+import java.security.Key;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Internal implementation of {@link KeyManager} that manages a single {@link Key}.
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ */
+final class DefaultKeyManager implements KeyManager {
+
+	private Key key;
+
+	DefaultKeyManager(Key key) {
+		Assert.notNull(key, "key cannot be null");
+		this.key = key;
+	}
+
+	@Override
+	public List<Key> getKeys() {
+		return Collections.singletonList(this.key);
+	}
+
+	@Override
+	public Key getActiveKey() {
+		return this.key;
+	}
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JoseHeaderNames.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JoseHeaderNames.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+/**
+ * The Registered Header Parameter Names defined by the JSON Web Signature (JWS) specification
+ * that may be contained in the JSON object JOSE Header.
+ *
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7515#section-4.1">JWS Headers</a>
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7797#section-3">B64 Header Parameter</a>
+ */
+public interface JoseHeaderNames {
+
+	String ALG = "alg";
+
+	String JKU = "jku";
+
+	String JWK = "jwk";
+
+	String KID = "kid";
+
+	String X5U = "x5u";
+
+	String X5C = "x5c";
+
+	String X5T = "x5t";
+
+	String X5T256 = "x5t#256";
+
+	String TYP = "typ";
+
+	String CTY = "cty";
+
+	String CRIT = "crit";
+
+	String B64 = "b64";
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JoseHeaders.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JoseHeaders.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.security.oauth2.core.converter.ClaimConversionService;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.util.Assert;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * A representation of &quot;headers&quot; that may be contained
+ * in the JSON object JOSE Header of a JSON Web Signature (JWS).
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7515#section-4">JOSE Header of JWS</a>
+ */
+public class JoseHeaders {
+
+	private final Map<String, Object> headers;
+
+	protected JoseHeaders(Map<String, Object> headers) {
+		Assert.notEmpty(headers, "headers cannot be empty");
+		this.headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
+	}
+
+	public SignatureAlgorithm getSignatureAlgorithm() {
+		return SignatureAlgorithm.from(getHeaderAsString("alg"));
+	}
+
+	public MacAlgorithm getMacAlgorithm() {
+		return MacAlgorithm.from(getHeaderAsString("alg"));
+	}
+
+	public String getType() {
+		return getHeaderAsString("typ");
+	}
+
+	public Map<String, Object> getHeaders() {
+		return this.headers;
+	}
+
+	public String getHeaderAsString(String header) {
+		return !containsHeader(header) ? null :
+				ClaimConversionService.getSharedInstance().convert(getHeaders().get(header), String.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> getHeaderAsStringList(String header) {
+		if (!containsHeader(header)) {
+			return null;
+		}
+		final TypeDescriptor sourceDescriptor = TypeDescriptor.valueOf(Object.class);
+		final TypeDescriptor targetDescriptor = TypeDescriptor.collection(
+				List.class, TypeDescriptor.valueOf(String.class));
+		Object headerValue = getHeaders().get(header);
+		List<String> convertedValue = (List<String>) ClaimConversionService.getSharedInstance().convert(
+				headerValue, sourceDescriptor, targetDescriptor);
+		if (convertedValue == null) {
+			throw new IllegalArgumentException("Unable to convert header '" + header +
+					"' of type '" + headerValue.getClass() + "' to List.");
+		}
+		return convertedValue;
+	}
+
+	public URI getHeaderAsURI(String header) {
+		if (!containsHeader(header)) {
+			return null;
+		}
+		Object headerValue = getHeaders().get(header);
+		URI convertedValue = ClaimConversionService.getSharedInstance().convert(headerValue, URI.class);
+		if (convertedValue == null) {
+			throw new IllegalArgumentException("Unable to convert header '" + header +
+					"' of type '" + headerValue.getClass() + "' to URI.");
+		}
+		return convertedValue;
+	}
+
+	public Boolean getHeaderAsBoolean(String header) {
+		return !containsHeader(header) ? null :
+				ClaimConversionService.getSharedInstance().convert(getHeaders().get(header), Boolean.class);
+	}
+
+	private Boolean containsHeader(String header) {
+		Assert.notNull(header, "header cannot be null");
+		return getHeaders().containsKey(header);
+	}
+
+	public static class Builder {
+		private Map<String, Object> headers = new LinkedHashMap<>();
+
+		public Builder() {
+		}
+
+		public Builder(JoseHeaders joseHeaders) {
+			Assert.notNull(joseHeaders, "joseHeaders cannot be null");
+			this.headers = joseHeaders.headers;
+		}
+
+		public Builder header(String name, Object value) {
+			Assert.notNull(name, "name cannot be null");
+			this.headers.put(name, value);
+			return this;
+		}
+
+		public Builder headers(Consumer<Map<String, Object>> headersConsumer) {
+			Assert.notNull(headersConsumer, "headersConsumer cannot be null");
+			headersConsumer.accept(this.headers);
+			return this;
+		}
+
+		public Builder signatureAlgorithm(SignatureAlgorithm signatureAlgorithm) {
+			Assert.notNull(signatureAlgorithm, "signatureAlgorithm cannot be null");
+			this.header("alg", signatureAlgorithm.getName());
+			return this;
+		}
+
+		public Builder macAlgorithm(MacAlgorithm macAlgorithm) {
+			Assert.notNull(macAlgorithm, "macAlgorithm cannot be null");
+			this.header("alg", macAlgorithm.getName());
+			return this;
+		}
+
+		public Builder type(String type) {
+			Assert.notNull(type, "type cannot be null");
+			this.header("typ", type);
+			return this;
+		}
+
+		public JoseHeaders build() {
+			return new JoseHeaders(this.headers);
+		}
+	}
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JwtClaimsSet.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JwtClaimsSet.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import org.springframework.security.oauth2.jwt.JwtClaimAccessor;
+import org.springframework.util.Assert;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * A representation of &quot;claims&quot; that may be contained
+ * in the JSON object JWT Claims Set of a JSON Web Token (JWT).
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7519#section-4">JWT Claims</a>
+ */
+public class JwtClaimsSet implements JwtClaimAccessor {
+
+	private final Map<String, Object> claims;
+
+	protected JwtClaimsSet(Map<String, Object> claims) {
+		Assert.notEmpty(claims, "claims cannot be null");
+		this.claims = Collections.unmodifiableMap(new LinkedHashMap<>(claims));
+	}
+
+	@Override
+	public Map<String, Object> getClaims() {
+		return this.claims;
+	}
+
+	public static class Builder {
+		private Map<String, Object> claims = new LinkedHashMap<>();
+
+		public Builder() {
+		}
+
+		public Builder(JwtClaimsSet jwtClaimsSet) {
+			Assert.notNull(jwtClaimsSet, "jwtClaimsSet cannot be null");
+			this.claims = jwtClaimsSet.claims;
+		}
+
+		public Builder claim(String name, Object value) {
+			Assert.notNull(name, "name cannot be null");
+			this.claims.put(name, value);
+			return this;
+		}
+
+		public Builder claims(Consumer<Map<String, Object>> claimsConsumer) {
+			Assert.notNull(claimsConsumer, "claimsConsumer cannot be null");
+			claimsConsumer.accept(this.claims);
+			return this;
+		}
+
+		public JwtClaimsSet build() {
+			return new JwtClaimsSet(this.claims);
+		}
+	}
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JwtEncoder.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/JwtEncoder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+/**
+ * Implementations of this interface are responsible for &quot;encoding&quot;
+ * a JSON Web Token (JWT) from it's unsecured representation {@link UnsecuredJwt}
+ * to secured representation {@link Jwt}.
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>
+ */
+@FunctionalInterface
+public interface JwtEncoder {
+
+	/**
+	 * Encodes the JWT from its unsecured format {@link UnsecuredJwt} and returns a {@link Jwt}.
+	 *
+	 * @param unsecuredJwt the unsecured JWT representation
+	 * @return a {@link Jwt}
+	 * @throws JwtException if an exception occurs while attempting to encode the JWT
+	 */
+	Jwt encode(UnsecuredJwt unsecuredJwt) throws JwtException;
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/KeyManager.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/KeyManager.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import java.security.Key;
+import java.util.List;
+
+/**
+ * A manager for the {@link Key}s.
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ */
+public interface KeyManager {
+
+	List<Key> getKeys();
+
+	Key getActiveKey();
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/NimbusJwtEncoder.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/NimbusJwtEncoder.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.KeyLengthException;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.X509CertChainUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.util.JSONArrayUtils;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.util.Assert;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.ALG;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.B64;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.CRIT;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.CTY;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.JKU;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.JWK;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.KID;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.TYP;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.X5C;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.X5T;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.X5T256;
+import static org.springframework.security.oauth2.server.authorization.jose.JoseHeaderNames.X5U;
+
+/**
+ * A low-level Nimbus implementation of {@link JwtEncoder} which takes a raw Nimbus configuration.
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ */
+public class NimbusJwtEncoder implements JwtEncoder {
+	private static final String ENCODING_ERROR_MESSAGE_TEMPLATE =
+			"An error occurred while attempting to encode the Jwt: %s";
+
+	private final JwsAlgorithm jwsAlgorithm;
+	private final JWSSigner jwsSigner;
+	private Consumer<JoseHeaders.Builder> joseHeadersCustomizer;
+	private Consumer<JwtClaimsSet.Builder> jwtClaimsSetCustomizer;
+
+	public NimbusJwtEncoder(JwsAlgorithm jwsAlgorithm, JWSSigner jwsSigner) {
+		Assert.notNull(jwsAlgorithm, "jwsAlgorithm cannot be null");
+		Assert.notNull(jwsSigner, "jwsSigner cannot be null");
+		this.jwsAlgorithm = jwsAlgorithm;
+		this.jwsSigner = jwsSigner;
+	}
+
+	@Override
+	public Jwt encode(UnsecuredJwt unsecuredJwt) throws JwtException {
+		// JWS Header
+		JoseHeaders.Builder headersBuilder = new JoseHeaders.Builder(unsecuredJwt.getHeaders());
+		if (jwsAlgorithm instanceof SignatureAlgorithm) {
+			headersBuilder = headersBuilder.signatureAlgorithm((SignatureAlgorithm) jwsAlgorithm);
+		} else if (jwsAlgorithm instanceof MacAlgorithm) {
+			headersBuilder = headersBuilder.macAlgorithm((MacAlgorithm) jwsAlgorithm);
+		}
+		headersBuilder = headersBuilder.type("JWT");
+		if (joseHeadersCustomizer != null) {
+			joseHeadersCustomizer.accept(headersBuilder);
+		}
+		final JoseHeaders joseHeaders = headersBuilder.build();
+		final JWSHeader jwsHeader = createJwsHeader(joseHeaders);
+
+		// JWT Claims Set
+		JwtClaimsSet.Builder claimsSetBuilder = new JwtClaimsSet.Builder(unsecuredJwt.getClaimsSet());
+		if (jwtClaimsSetCustomizer != null) {
+			jwtClaimsSetCustomizer.accept(claimsSetBuilder);
+		}
+		final JwtClaimsSet claimsSet = claimsSetBuilder.build();
+		final JWTClaimsSet jwtClaimsSet = createJwtClaimsSet(claimsSet);
+
+		// Nimbus JWT representation
+		SignedJWT signedJwt = new SignedJWT(jwsHeader, jwtClaimsSet);
+		try {
+			// sign the Nimbus JWT
+			signedJwt.sign(jwsSigner);
+		} catch (JOSEException ex) {
+			throw new JwtException(String.format(ENCODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
+		}
+
+		// Build JWT with compact serialized value, headers and claims set
+		return Jwt.withTokenValue(signedJwt.serialize())
+				.headers(headers -> headers.putAll(joseHeaders.getHeaders()))
+				.claims(claims -> claims.putAll(claimsSet.getClaims()))
+				.build();
+	}
+
+	public void setJoseHeadersCustomizer(Consumer<JoseHeaders.Builder> joseHeadersCustomizer) {
+		this.joseHeadersCustomizer = joseHeadersCustomizer;
+	}
+
+	public void setJwtClaimsSetCustomizer(Consumer<JwtClaimsSet.Builder> jwtClaimsSetCustomizer) {
+		this.jwtClaimsSetCustomizer = jwtClaimsSetCustomizer;
+	}
+
+	@SuppressWarnings("StatementWithEmptyBody")
+	private JWSHeader createJwsHeader(JoseHeaders headers) {
+		JWSHeader.Builder jwsHeaderBuilder = new JWSHeader.Builder(
+				JWSAlgorithm.parse(headers.getHeaderAsString(ALG)));
+		// Parse optional and custom header parameters
+		Map<String, Object> headersMap = headers.getHeaders();
+		try {
+			for (final String name: headersMap.keySet()) {
+				if (ALG.equals(name)) {
+					// skip as alg is already set
+				} else if (TYP.equals(name)) {
+					String typValue = headers.getType();
+					if (typValue != null) {
+						jwsHeaderBuilder = jwsHeaderBuilder.type(new JOSEObjectType(typValue));
+					}
+				} else if (CTY.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.contentType(headers.getHeaderAsString(CTY));
+				} else if (CRIT.equals(name)) {
+					List<String> critValues = headers.getHeaderAsStringList(CRIT);
+					if (critValues != null) {
+						jwsHeaderBuilder = jwsHeaderBuilder.criticalParams(new HashSet<>(critValues));
+					}
+				} else if (JKU.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.jwkURL(headers.getHeaderAsURI(JKU));
+				} else if (JWK.equals(name)) {
+					String jwkAsString = headers.getHeaderAsString(JWK);
+					if (jwkAsString != null) {
+						jwsHeaderBuilder = jwsHeaderBuilder.jwk(com.nimbusds.jose.jwk.JWK.parse(jwkAsString));
+					}
+				} else if (X5U.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.x509CertURL(headers.getHeaderAsURI(X5U));
+				} else if (X5T.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.x509CertThumbprint(
+							Base64URL.from(headers.getHeaderAsString(X5T)));
+				} else if (X5T256.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.x509CertSHA256Thumbprint(
+							Base64URL.from(headers.getHeaderAsString(X5T256)));
+				} else if (X5C.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.x509CertChain(
+							X509CertChainUtils.toBase64List(JSONArrayUtils.parse(headers.getHeaderAsString(X5C))));
+				} else if (KID.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.keyID(headers.getHeaderAsString(KID));
+				} else if (B64.equals(name)) {
+					jwsHeaderBuilder = jwsHeaderBuilder.base64URLEncodePayload(headers.getHeaderAsBoolean(B64));
+				} else {
+					jwsHeaderBuilder = jwsHeaderBuilder.customParam(name, headersMap.get(name));
+				}
+			}
+		} catch (Exception ex) {
+			throw new JwtException(String.format(ENCODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
+		}
+		return jwsHeaderBuilder.build();
+	}
+
+	private JWTClaimsSet createJwtClaimsSet(JwtClaimsSet claimsSet) {
+		JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder();
+		claimsSet.getClaims().forEach(jwtClaimsSetBuilder::claim);
+		return jwtClaimsSetBuilder.build();
+	}
+
+	public static class KeyManagerJwtEncoderBuilder {
+		private KeyManager keyManager;
+		private JwsAlgorithm jwsAlgorithm;
+
+		public KeyManagerJwtEncoderBuilder(KeyManager keyManager) {
+			Assert.notNull(keyManager, "keyManager cannot be null");
+			this.keyManager = keyManager;
+			this.jwsAlgorithm = SignatureAlgorithm.RS256;
+		}
+
+		public KeyManagerJwtEncoderBuilder jwsAlgorithm(JwsAlgorithm jwsAlgorithm) {
+			Assert.notNull(jwsAlgorithm, "jwsAlgorithm cannot be null");
+			this.jwsAlgorithm = jwsAlgorithm;
+			return this;
+		}
+
+		public NimbusJwtEncoder build() {
+			Key key = keyManager.getActiveKey();
+			JWSSigner jwsSigner;
+			if (key instanceof RSAPrivateKey) {
+				if (!JWSAlgorithm.Family.RSA.contains(JWSAlgorithm.parse(this.jwsAlgorithm.getName()))) {
+					throw new IllegalStateException("The provided key is of type RSA; " +
+							"however the JWS algorithm is of some other type: " +
+							this.jwsAlgorithm + ". Please indicate one of RS256, RS384, or RS512.");
+				}
+				jwsSigner = new RSASSASigner((RSAPrivateKey) key);
+			} else if (key instanceof SecretKey) {
+				if (!JWSAlgorithm.Family.HMAC_SHA.contains(JWSAlgorithm.parse(this.jwsAlgorithm.getName()))) {
+					throw new IllegalStateException("The provided key is of type HMAC_SHA; " +
+							"however the JWS algorithm is of some other type: " +
+							this.jwsAlgorithm + ". Please indicate one of HS256, HS384, or HS512.");
+				}
+				try {
+					jwsSigner = new MACSigner((SecretKey) key);
+				} catch (KeyLengthException ex) {
+					throw new IllegalStateException("The provided secret key is invalid.", ex);
+				}
+			} else {
+				throw new IllegalStateException("Unsupported key provided.");
+			}
+			return new NimbusJwtEncoder(jwsAlgorithm, jwsSigner);
+		}
+	}
+}

--- a/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/UnsecuredJwt.java
+++ b/core/src/main/java/org/springframework/security/oauth2/server/authorization/jose/UnsecuredJwt.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jose;
+
+import org.springframework.util.Assert;
+
+/**
+ * A representation of Unsecured JWT defined by JSON Web Token (JWT).
+ *
+ * @author Anoop Garlapati
+ * @since 0.0.1
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7519#section-6">Unsecured JWT</a>
+ */
+public class UnsecuredJwt {
+	private final JoseHeaders headers;
+	private final JwtClaimsSet claimsSet;
+
+	public UnsecuredJwt(JoseHeaders headers, JwtClaimsSet claimsSet) {
+		Assert.notNull(headers, "headers cannot be null");
+		Assert.notNull(claimsSet, "claimsSet cannot be null");
+		this.headers = headers;
+		this.claimsSet = claimsSet;
+	}
+
+	public JoseHeaders getHeaders() {
+		return this.headers;
+	}
+
+	public JwtClaimsSet getClaimsSet() {
+		return this.claimsSet;
+	}
+}


### PR DESCRIPTION
Issue gh-81

**Implementation Requirements**
- [x] define interface JwtEncoder
- [x] provide an implementation of JwtEncoder - NimbusJwtEncoder NOTE: The implementation should use the Nimbus JOSE + JWT library
- [x] the NimbusJwtEncoder should have a Builder
- [x] the NimbusJwtEncoder should support HS256 (HMAC using SHA-256)
- [x] the NimbusJwtEncoder should support RS256 (RSASSA-PKCS1-v1_5 using SHA-256)
- [x] the NimbusJwtEncoder should have a "KeyManager" that provides the public/private/symmetric keys (also required by #82)
- [ ] the NimbusJwtEncoder should be used by OAuth2AuthorizationCodeAuthenticationProvider #68 to produce a JWS
- [ ] javadoc class and public methods
- [ ] Unit tests