### PR TITLE
Rename and move SpringSecurityCoreVersion2 to Version

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/crypto/keys/ManagedKey.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/crypto/keys/ManagedKey.java
@@ -16,7 +16,7 @@
 package org.springframework.security.crypto.keys;
 
 import org.springframework.lang.Nullable;
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.util.Assert;
 
 import javax.crypto.SecretKey;
@@ -35,7 +35,7 @@ import java.util.Objects;
  * @see KeyManager
  */
 public final class ManagedKey implements Serializable {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private Key key;
 	private PublicKey publicKey;
 	private String keyId;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/InMemoryOAuth2AuthorizationService.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/InMemoryOAuth2AuthorizationService.java
@@ -16,7 +16,7 @@
 package org.springframework.security.oauth2.server.authorization;
 
 import org.springframework.lang.Nullable;
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.util.Assert;
 
 import java.io.Serializable;
@@ -63,7 +63,7 @@ public final class InMemoryOAuth2AuthorizationService implements OAuth2Authoriza
 	}
 
 	private static class OAuth2AuthorizationId implements Serializable {
-		private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+		private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 		private final String registeredClientId;
 		private final String principalName;
 

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization;
 
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.util.Assert;
@@ -39,7 +39,7 @@ import java.util.function.Consumer;
  * @see OAuth2AccessToken
  */
 public class OAuth2Authorization implements Serializable {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private String registeredClientId;
 	private String principalName;
 	private OAuth2AccessToken accessToken;
@@ -146,7 +146,7 @@ public class OAuth2Authorization implements Serializable {
 	 * A builder for {@link OAuth2Authorization}.
 	 */
 	public static class Builder implements Serializable {
-		private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+		private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 		private String registeredClientId;
 		private String principalName;
 		private OAuth2AccessToken accessToken;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/TokenType.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/TokenType.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization;
 
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.util.Assert;
 
 import java.io.Serializable;
@@ -24,7 +24,7 @@ import java.io.Serializable;
  * @author Joe Grandja
  */
 public final class TokenType implements Serializable {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	public static final TokenType ACCESS_TOKEN = new TokenType("access_token");
 	public static final TokenType AUTHORIZATION_CODE = new TokenType("authorization_code");
 	private final String value;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/Version.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/Version.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.security.core;
+package org.springframework.security.oauth2.server.authorization;
 
 /**
  * Internal class used for serialization across Spring Security Authorization Server classes.
@@ -21,7 +21,7 @@ package org.springframework.security.core;
  * @author Anoop Garlapati
  * @since 0.0.1
  */
-public final class SpringSecurityCoreVersion2 {
+public final class Version {
 	private static final int MAJOR = 0;
 	private static final int MINOR = 0;
 	private static final int PATCH = 2;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AccessTokenAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AccessTokenAuthenticationToken.java
@@ -17,7 +17,7 @@ package org.springframework.security.oauth2.server.authorization.authentication;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.util.Assert;
@@ -37,7 +37,7 @@ import java.util.Collections;
  * @see OAuth2ClientAuthenticationToken
  */
 public class OAuth2AccessTokenAuthenticationToken extends AbstractAuthenticationToken {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private final RegisteredClient registeredClient;
 	private final Authentication clientPrincipal;
 	private final OAuth2AccessToken accessToken;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationToken.java
@@ -18,7 +18,7 @@ package org.springframework.security.oauth2.server.authorization.authentication;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.util.Assert;
 
 import java.util.Collections;
@@ -34,7 +34,7 @@ import java.util.Collections;
  * @see OAuth2ClientAuthenticationToken
  */
 public class OAuth2AuthorizationCodeAuthenticationToken extends AbstractAuthenticationToken {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private String code;
 	private Authentication clientPrincipal;
 	private String clientId;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationToken.java
@@ -18,7 +18,7 @@ package org.springframework.security.oauth2.server.authorization.authentication;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.util.Assert;
 
@@ -35,7 +35,7 @@ import java.util.Collections;
  * @see OAuth2ClientAuthenticationProvider
  */
 public class OAuth2ClientAuthenticationToken extends AbstractAuthenticationToken {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private String clientId;
 	private String clientSecret;
 	private RegisteredClient registeredClient;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationToken.java
@@ -17,7 +17,7 @@ package org.springframework.security.oauth2.server.authorization.authentication;
 
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.util.Assert;
 
 import java.util.Collections;
@@ -34,7 +34,7 @@ import java.util.Set;
  * @see OAuth2ClientAuthenticationToken
  */
 public class OAuth2ClientCredentialsAuthenticationToken extends AbstractAuthenticationToken {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private final Authentication clientPrincipal;
 	private final Set<String> scopes;
 

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/RegisteredClient.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/RegisteredClient.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization.client;
 
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.server.authorization.config.ClientSettings;
@@ -40,7 +40,7 @@ import java.util.function.Consumer;
  * @since 0.0.1
  */
 public class RegisteredClient implements Serializable {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private String id;
 	private String clientId;
 	private String clientSecret;
@@ -174,7 +174,7 @@ public class RegisteredClient implements Serializable {
 	 * A builder for {@link RegisteredClient}.
 	 */
 	public static class Builder implements Serializable {
-		private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+		private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 		private String id;
 		private String clientId;
 		private String clientSecret;

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/Settings.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/Settings.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization.config;
 
-import org.springframework.security.core.SpringSecurityCoreVersion2;
+import org.springframework.security.oauth2.server.authorization.Version;
 import org.springframework.util.Assert;
 
 import java.io.Serializable;
@@ -30,7 +30,7 @@ import java.util.function.Consumer;
  * @since 0.0.2
  */
 public class Settings implements Serializable {
-	private static final long serialVersionUID = SpringSecurityCoreVersion2.SERIAL_VERSION_UID;
+	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private final Map<String, Object> settings;
 
 	/**


### PR DESCRIPTION
I've renamed and moved org.springframework.security.oauth2.server.authorization.SpringSecurityCoreVersion2.java to org.springframework.security.oauth2.server.authorization.Version.java

Closes gh-116