### PR TITLE
Refresh token should not be issued if client is not configured with refresh_token grant type#155

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -18,11 +18,7 @@ package org.springframework.security.oauth2.server.authorization.authentication;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
-import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.*;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
@@ -126,7 +122,7 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
 				.accessToken(accessToken);
 
 		OAuth2RefreshToken refreshToken = null;
-		if (registeredClient.getTokenSettings().enableRefreshTokens()) {
+		if (isConfiguredForRefreshToken(registeredClient)) {
 			refreshToken = OAuth2TokenIssuerUtil.issueRefreshToken(registeredClient.getTokenSettings().refreshTokenTimeToLive());
 			tokensBuilder.refreshToken(refreshToken);
 		}
@@ -148,5 +144,10 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
 	@Override
 	public boolean supports(Class<?> authentication) {
 		return OAuth2AuthorizationCodeAuthenticationToken.class.isAssignableFrom(authentication);
+	}
+
+	private boolean isConfiguredForRefreshToken(RegisteredClient registeredClient) {
+		return registeredClient.getTokenSettings().enableRefreshTokens() &&
+				registeredClient.getAuthorizationGrantTypes().contains(AuthorizationGrantType.REFRESH_TOKEN);
 	}
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -18,7 +18,12 @@ package org.springframework.security.oauth2.server.authorization.authentication;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.oauth2.core.*;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
@@ -122,7 +127,8 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
 				.accessToken(accessToken);
 
 		OAuth2RefreshToken refreshToken = null;
-		if (isConfiguredForRefreshToken(registeredClient)) {
+		if (registeredClient.getAuthorizationGrantTypes()
+				.contains(AuthorizationGrantType.REFRESH_TOKEN)) {
 			refreshToken = OAuth2TokenIssuerUtil.issueRefreshToken(registeredClient.getTokenSettings().refreshTokenTimeToLive());
 			tokensBuilder.refreshToken(refreshToken);
 		}
@@ -146,8 +152,4 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
 		return OAuth2AuthorizationCodeAuthenticationToken.class.isAssignableFrom(authentication);
 	}
 
-	private boolean isConfiguredForRefreshToken(RegisteredClient registeredClient) {
-		return registeredClient.getTokenSettings().enableRefreshTokens() &&
-				registeredClient.getAuthorizationGrantTypes().contains(AuthorizationGrantType.REFRESH_TOKEN);
-	}
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/TokenSettings.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/TokenSettings.java
@@ -31,7 +31,6 @@ import java.util.Map;
 public class TokenSettings extends Settings {
 	private static final String TOKEN_SETTING_BASE = "setting.token.";
 	public static final String ACCESS_TOKEN_TIME_TO_LIVE = TOKEN_SETTING_BASE.concat("access-token-time-to-live");
-	public static final String ENABLE_REFRESH_TOKENS = TOKEN_SETTING_BASE.concat("enable-refresh-tokens");
 	public static final String REUSE_REFRESH_TOKENS = TOKEN_SETTING_BASE.concat("reuse-refresh-tokens");
 	public static final String REFRESH_TOKEN_TIME_TO_LIVE = TOKEN_SETTING_BASE.concat("refresh-token-time-to-live");
 
@@ -70,26 +69,6 @@ public class TokenSettings extends Settings {
 		Assert.notNull(accessTokenTimeToLive, "accessTokenTimeToLive cannot be null");
 		Assert.isTrue(accessTokenTimeToLive.getSeconds() > 0, "accessTokenTimeToLive must be greater than Duration.ZERO");
 		setting(ACCESS_TOKEN_TIME_TO_LIVE, accessTokenTimeToLive);
-		return this;
-	}
-
-	/**
-	 * Returns {@code true} if refresh tokens are enabled. The default is {@code true}.
-	 *
-	 * @return {@code true} if refresh tokens are enabled, {@code false} otherwise
-	 */
-	public boolean enableRefreshTokens() {
-		return setting(ENABLE_REFRESH_TOKENS);
-	}
-
-	/**
-	 * Set to {@code true} to enable refresh tokens.
-	 *
-	 * @param enableRefreshTokens {@code true} to enable refresh tokens, {@code false} otherwise
-	 * @return the {@link TokenSettings}
-	 */
-	public TokenSettings enableRefreshTokens(boolean enableRefreshTokens) {
-		setting(ENABLE_REFRESH_TOKENS, enableRefreshTokens);
 		return this;
 	}
 
@@ -138,7 +117,6 @@ public class TokenSettings extends Settings {
 	protected static Map<String, Object> defaultSettings() {
 		Map<String, Object> settings = new HashMap<>();
 		settings.put(ACCESS_TOKEN_TIME_TO_LIVE, Duration.ofMinutes(5));
-		settings.put(ENABLE_REFRESH_TOKENS, true);
 		settings.put(REUSE_REFRESH_TOKENS, true);
 		settings.put(REFRESH_TOKEN_TIME_TO_LIVE, Duration.ofMinutes(60));
 		return settings;

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProviderTests.java
@@ -252,7 +252,7 @@ public class OAuth2AuthorizationCodeAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenValidCodeThenReturnAccessTokenButNotRefreshTokenIfClientHasNoRefreshTokenGrantType() {
-		RegisteredClient registeredClient = TestRegisteredClients.registeredClient3().build();
+		RegisteredClient registeredClient = TestRegisteredClients.registeredPublicClient().build();
 		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization(registeredClient).build();
 		when(this.authorizationService.findByToken(eq(AUTHORIZATION_CODE), eq(TokenType.AUTHORIZATION_CODE)))
 				.thenReturn(authorization);
@@ -356,30 +356,6 @@ public class OAuth2AuthorizationCodeAuthenticationProviderTests {
 		Instant expectedRefreshTokenExpiresAt = accessTokenAuthentication.getRefreshToken().getIssuedAt().plus(refreshTokenTTL);
 		assertThat(accessTokenAuthentication.getRefreshToken().getExpiresAt()).isBetween(
 				expectedRefreshTokenExpiresAt.minusSeconds(1), expectedRefreshTokenExpiresAt.plusSeconds(1));
-	}
-
-	@Test
-	public void authenticateWhenRefreshTokenDisabledThenRefreshTokenNull() {
-		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
-				.tokenSettings(tokenSettings -> tokenSettings.enableRefreshTokens(false))
-				.build();
-
-		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization(registeredClient).build();
-		when(this.authorizationService.findByToken(eq(AUTHORIZATION_CODE), eq(TokenType.AUTHORIZATION_CODE)))
-				.thenReturn(authorization);
-
-		OAuth2ClientAuthenticationToken clientPrincipal = new OAuth2ClientAuthenticationToken(registeredClient);
-		OAuth2AuthorizationRequest authorizationRequest = authorization.getAttribute(
-				OAuth2AuthorizationAttributeNames.AUTHORIZATION_REQUEST);
-		OAuth2AuthorizationCodeAuthenticationToken authentication =
-				new OAuth2AuthorizationCodeAuthenticationToken(AUTHORIZATION_CODE, clientPrincipal, authorizationRequest.getRedirectUri(), null);
-
-		when(this.jwtEncoder.encode(any(), any())).thenReturn(createJwt());
-
-		OAuth2AccessTokenAuthenticationToken accessTokenAuthentication =
-				(OAuth2AccessTokenAuthenticationToken) this.authenticationProvider.authenticate(authentication);
-
-		assertThat(accessTokenAuthentication.getRefreshToken()).isNull();
 	}
 
 	private static Jwt createJwt() {

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
@@ -53,18 +53,6 @@ public class TestRegisteredClients {
 				.scope("scope2");
 	}
 
-	public static RegisteredClient.Builder registeredClient3() {
-		return RegisteredClient.withId("registration-3")
-				.clientId("client-3")
-				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-				.clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
-				.redirectUri("https://example.com")
-				.scope("openid")
-				.scope("profile")
-				.scope("email")
-				.clientSettings(clientSettings -> clientSettings.requireProofKey(true));
-	}
-
 	public static RegisteredClient.Builder registeredPublicClient() {
 		return RegisteredClient.withId("registration-3")
 				.clientId("client-3")
@@ -74,7 +62,6 @@ public class TestRegisteredClients {
 				.scope("openid")
 				.scope("profile")
 				.scope("email")
-				.clientSettings(clientSettings -> clientSettings.requireProofKey(true))
-				.tokenSettings(tokenSettings -> tokenSettings.enableRefreshTokens(false));
+				.clientSettings(clientSettings -> clientSettings.requireProofKey(true));
 	}
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
@@ -53,6 +53,18 @@ public class TestRegisteredClients {
 				.scope("scope2");
 	}
 
+	public static RegisteredClient.Builder registeredClient3() {
+		return RegisteredClient.withId("registration-3")
+				.clientId("client-3")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+				.redirectUri("https://example.com")
+				.scope("openid")
+				.scope("profile")
+				.scope("email")
+				.clientSettings(clientSettings -> clientSettings.requireProofKey(true));
+	}
+
 	public static RegisteredClient.Builder registeredPublicClient() {
 		return RegisteredClient.withId("registration-3")
 				.clientId("client-3")

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/config/TokenSettingsTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/config/TokenSettingsTests.java
@@ -32,9 +32,8 @@ public class TokenSettingsTests {
 	@Test
 	public void constructorWhenDefaultThenDefaultsAreSet() {
 		TokenSettings tokenSettings = new TokenSettings();
-		assertThat(tokenSettings.settings()).hasSize(4);
+		assertThat(tokenSettings.settings()).hasSize(3);
 		assertThat(tokenSettings.accessTokenTimeToLive()).isEqualTo(Duration.ofMinutes(5));
-		assertThat(tokenSettings.enableRefreshTokens()).isTrue();
 		assertThat(tokenSettings.reuseRefreshTokens()).isTrue();
 		assertThat(tokenSettings.refreshTokenTimeToLive()).isEqualTo(Duration.ofMinutes(60));
 	}
@@ -69,12 +68,6 @@ public class TokenSettingsTests {
 				.isInstanceOf(IllegalArgumentException.class)
 				.extracting(Throwable::getMessage)
 				.isEqualTo("accessTokenTimeToLive must be greater than Duration.ZERO");
-	}
-
-	@Test
-	public void enableRefreshTokensWhenFalseThenSet() {
-		TokenSettings tokenSettings = new TokenSettings().enableRefreshTokens(false);
-		assertThat(tokenSettings.enableRefreshTokens()).isFalse();
 	}
 
 	@Test
@@ -115,9 +108,8 @@ public class TokenSettingsTests {
 				.<TokenSettings>setting("name1", "value1")
 				.accessTokenTimeToLive(accessTokenTimeToLive)
 				.<TokenSettings>settings(settings -> settings.put("name2", "value2"));
-		assertThat(tokenSettings.settings()).hasSize(6);
+		assertThat(tokenSettings.settings()).hasSize(5);
 		assertThat(tokenSettings.accessTokenTimeToLive()).isEqualTo(accessTokenTimeToLive);
-		assertThat(tokenSettings.enableRefreshTokens()).isTrue();
 		assertThat(tokenSettings.reuseRefreshTokens()).isTrue();
 		assertThat(tokenSettings.refreshTokenTimeToLive()).isEqualTo(Duration.ofMinutes(60));
 		assertThat(tokenSettings.<String>setting("name1")).isEqualTo("value1");

--- a/samples/boot/oauth2-integration/authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
+++ b/samples/boot/oauth2-integration/authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
@@ -41,13 +41,14 @@ public class AuthorizationServerConfig {
 	@Bean
 	public RegisteredClientRepository registeredClientRepository() {
 		RegisteredClient registeredClient = RegisteredClient.withId(UUID.randomUUID().toString())
-				.clientId("messaging-client")
+				.clientId("client")
 				.clientSecret("secret")
 				.clientAuthenticationMethod(ClientAuthenticationMethod.BASIC)
 				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+//				.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
 				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
 				.redirectUri("http://localhost:8080/authorized")
-				.scope("message.read")
+				.scope("read")
 				.scope("message.write")
 				.clientSettings(clientSettings -> clientSettings.requireUserConsent(true))
 				.build();


### PR DESCRIPTION
A refresh token was generated even if the client didn't have the refresh token grant type assigned.
The refresh token is now generated only for a client registered for the refresh token grant type.

Closes gh-155