### PR TITLE
Bump Jacoco to 0.8.6

### DIFF
--- a/oauth2-authorization-server/spring-security-oauth2-authorization-server.gradle
+++ b/oauth2-authorization-server/spring-security-oauth2-authorization-server.gradle
@@ -20,5 +20,5 @@ dependencies {
 }
 
 jacoco {
-	toolVersion = '0.8.5'
+	toolVersion = '0.8.6'
 }


### PR DESCRIPTION
Jacoco 0.8.6 supports Java 15 (while 0.8.5 doesn't).