### PR TITLE
Ensure that the access token response "scope" shows the scopes in the JWT

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -167,9 +167,11 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
 		JwtClaimsSet claims = context.getClaims().build();
 		Jwt jwtAccessToken = this.jwtEncoder.encode(headers, claims);
 
+		Set<String> customizedScopes = new HashSet<>(claims.getClaimAsStringList(OAuth2ParameterNames.SCOPE));
+
 		OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				jwtAccessToken.getTokenValue(), jwtAccessToken.getIssuedAt(),
-				jwtAccessToken.getExpiresAt(), excludeOpenidIfNecessary(authorizedScopes));
+				jwtAccessToken.getExpiresAt(), excludeOpenidIfNecessary(customizedScopes));
 
 		OAuth2RefreshToken refreshToken = null;
 		if (registeredClient.getAuthorizationGrantTypes().contains(AuthorizationGrantType.REFRESH_TOKEN)) {


### PR DESCRIPTION
Since the `scope` claim can be customized, we have to make sure that the access token response `scope` field shows the same scopes as the customized claim.

TODO: If this implementation makes sense I'll work on an accompanying test. This didn't feel like it naturally fit into another test.