### PR TITLE
WIP for feedback: Prototype to remember user consent decisions

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/consent/InMemoryUserConsentRepository.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/consent/InMemoryUserConsentRepository.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.consent;
+
+import org.springframework.util.Assert;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class InMemoryUserConsentRepository implements UserConsentRepository {
+
+	private final Set<UserConsentRecord> userConsentRecords = new HashSet<>();
+
+	@Override
+	public Set<UserConsentRecord> findBySubjectAndClientId(final String subject, final String clientId) {
+		Assert.hasText(subject, "subject must have text");
+		Assert.hasText(clientId, "clientId must have text");
+
+		return this.userConsentRecords
+				.stream()
+				.filter(record -> subject.equals(record.getSubject()))
+				.filter(record -> clientId.equals(record.getClientId()))
+				.filter(UserConsentRecord::isValid)
+				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public void saveAll(String subject, String clientId, Set<String> consentedScopes) {
+		Assert.hasText(subject, "subject must have text");
+		Assert.hasText(clientId, "clientId must have text");
+		Assert.notNull(consentedScopes, "consentedScopes must not be null");
+
+		Function<String, UserConsentRecord> mapScopeToConsent = (scope) -> new UserConsentRecord(
+				subject,
+				clientId,
+				scope);
+
+		// remove any older consent records
+		this.revokeAll(subject, clientId, consentedScopes);
+		this.userConsentRecords.addAll(consentedScopes.stream().map(mapScopeToConsent).collect(Collectors.toSet()));
+	}
+
+	@Override
+	public void revokeAll(String subject, String clientId, Set<String> revokedScopes) {
+		Assert.hasText(subject, "subject must have text");
+		Assert.hasText(clientId, "clientId must have text");
+		Assert.notNull(revokedScopes, "revokedScopes must not be null");
+
+		revokedScopes.forEach(revokedScope -> this.revokeSingle(subject, clientId, revokedScope));
+	}
+
+	private void revokeSingle(String subject, String clientId, String revokedScope) {
+		this.userConsentRecords
+				.stream()
+				.filter(record -> subject.equals(record.getSubject()))
+				.filter(record -> clientId.equals(record.getClientId()))
+				.filter(record -> revokedScope.equals(record.getAuthorizedScope()))
+				.findFirst()
+				.ifPresent(this.userConsentRecords::remove);
+	}
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/consent/UserConsentRecord.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/consent/UserConsentRecord.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.consent;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public class UserConsentRecord {
+
+	private final String subject;
+	private final String clientId;
+	private final String authorizedScope;
+	private final Instant consentGrantedTime;
+	private final Duration lifetime;
+
+	public UserConsentRecord(
+			final String subject,
+			final String clientId,
+			final String authorizedScope) {
+		this.subject = subject;
+		this.clientId = clientId;
+		this.authorizedScope = authorizedScope;
+		// TODO: consentGrantedTime should be passed in so that it truly reflects when the consent was granted
+		this.consentGrantedTime = Instant.now();
+		// TODO:
+		this.lifetime = Duration.ofDays(7);
+	}
+
+	public String getSubject() {
+		return this.subject;
+	}
+
+	public String getClientId() {
+		return this.clientId;
+	}
+
+	public String getAuthorizedScope() {
+		return this.authorizedScope;
+	}
+
+	public boolean isValid() {
+		return Instant.now().isBefore(this.consentGrantedTime.plus(this.lifetime));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof UserConsentRecord)) return false;
+		UserConsentRecord that = (UserConsentRecord) o;
+		return Objects.equals(subject, that.subject)
+				&& Objects.equals(clientId, that.clientId)
+				&& Objects.equals(authorizedScope, that.authorizedScope)
+				&& Objects.equals(consentGrantedTime, that.consentGrantedTime)
+				&& Objects.equals(lifetime, that.lifetime);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(subject, clientId, authorizedScope, consentGrantedTime, lifetime);
+	}
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/consent/UserConsentRepository.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/consent/UserConsentRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.consent;
+
+import java.util.Set;
+
+public interface UserConsentRepository {
+
+	Set<UserConsentRecord> findBySubjectAndClientId(String subject, String clientId);
+
+	void saveAll(String subject, String clientId, Set<String> consentedScopes);
+
+	void revokeAll(String subject, String clientId, Set<String> revokedScopes);
+}


### PR DESCRIPTION
A user scope consent decisions can have a lifecycle outside of the context of an authorization code grant. For example, if a user `user` grants scope `message.read` to client `message-client`, this consent decision could live for 7 days, or 30 days, or be revokable by the user.

This is only a prototype to indicate how this might fit in with the current flow of `OAuth2AuthorizationEndpointFilter`.

TODO:
- Remove any extraneous lines (such as `imports` that were moved accidentally)
- Provide a sample `HttpSession`-based implementation of `UserConsentRepository`
- Needs tests!
- `UserConsentRepository` should be a bean that's injected via context, not created inside of `OAuth2AuthorizationEndpointFilter`
- Note that the consent lookups use `subject` and `clientId`. Right now `subject` is the name of the principal, but this is really not a long-term solution. Authentication could be delegated to multiple upstream identity providers, each of which returns the same name for the principal. `clientId` also has problems, for example if that client is deleted, all of the consent decisions related to that client should be revoked else a new client with the same `clientId` will inherit those consent decisions.

Helpful feedback appreciated!