### PR TITLE
Use nimbus-jose-jwt and oauth2-oidc-sdk versions from spring-security

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=0.1.1-SNAPSHOT
-springBootVersion=2.4.2
+springBootVersion=2.4.3
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -3,7 +3,7 @@ if (!project.hasProperty("springVersion")) {
 }
 
 if (!project.hasProperty("springSecurityVersion")) {
-	ext.springSecurityVersion = "5.4.2"
+	ext.springSecurityVersion = "5.4.5"
 }
 
 if (!project.hasProperty("reactorVersion")) {
@@ -25,8 +25,6 @@ dependencyManagement {
 	}
 
 	dependencies {
-		dependency "com.nimbusds:oauth2-oidc-sdk:8.23.1"
-		dependency "com.nimbusds:nimbus-jose-jwt:9.1.3"
 		dependency "javax.servlet:javax.servlet-api:4.0.1"
 		dependency 'junit:junit:4.13.1'
 		dependency 'org.assertj:assertj-core:3.18.1'

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwsEncoder.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwsEncoder.java
@@ -43,6 +43,7 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
+import net.minidev.json.JSONObject;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -197,7 +198,7 @@ public final class NimbusJwsEncoder implements JwtEncoder {
 			Map<String, Object> jwk = headers.getJwk();
 			if (!CollectionUtils.isEmpty(jwk)) {
 				try {
-					builder.jwk(JWK.parse(jwk));
+					builder.jwk(JWK.parse(new JSONObject(jwk)));
 				}
 				catch (Exception ex) {
 					throw new JwtEncodingException(String.format(ENCODING_ERROR_MESSAGE_TEMPLATE,


### PR DESCRIPTION
- Spring Security 5.4.5 downgraded nimbus-jose-jwt to 8.+ from 9.+,
  which breaks NimbusJwsEncoder.
- In order to be compatible with both 9.+ (in Security up to
  5.4.4 included) and with 8.+ (in Security 5.4.5), we need to use JSONObjects
  from `json-smart`, which was bundled with nimbus 8.+ but not with 9.+

Tested with both springSecurityVersion = 5.4.2 and 5.4.5

Samples tested with:
- Boot 2.4.2
- Boot 2.4.3 + Security 5.4.5 (the version bundled in boot

closes #256 