### PR TITLE
Fix samples: use loopback IP, merge filter chains

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/config/annotation/web/configuration/OAuth2AuthorizationServerConfiguration.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/config/annotation/web/configuration/OAuth2AuthorizationServerConfiguration.java
@@ -37,24 +37,33 @@ public class OAuth2AuthorizationServerConfiguration {
 	@Bean
 	@Order(Ordered.HIGHEST_PRECEDENCE)
 	public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
-		applyDefaultSecurity(http);
+		applyDefaultSecurity(http, true);
 		return http.build();
 	}
 
 	// @formatter:off
 	public static void applyDefaultSecurity(HttpSecurity http) throws Exception {
+		applyDefaultSecurity(http, false);
+	}
+	// @formatter:on
+
+	// @formatter:off
+	private static void applyDefaultSecurity(HttpSecurity http, boolean onlyApplyToAuthorizationServerEndpoints) throws Exception {
 		OAuth2AuthorizationServerConfigurer<HttpSecurity> authorizationServerConfigurer =
 				new OAuth2AuthorizationServerConfigurer<>();
 		RequestMatcher endpointsMatcher = authorizationServerConfigurer
 				.getEndpointsMatcher();
 
 		http
-			.requestMatcher(endpointsMatcher)
 			.authorizeRequests(authorizeRequests ->
-				authorizeRequests.anyRequest().authenticated()
+					authorizeRequests.requestMatchers(endpointsMatcher).authenticated()
 			)
 			.csrf(csrf -> csrf.ignoringRequestMatchers(endpointsMatcher))
 			.apply(authorizationServerConfigurer);
+
+		if (onlyApplyToAuthorizationServerEndpoints) {
+			http.requestMatcher(endpointsMatcher);
+		}
 	}
 	// @formatter:on
 }

--- a/samples/boot/oauth2-integration/README.adoc
+++ b/samples/boot/oauth2-integration/README.adoc
@@ -8,4 +8,4 @@ This sample integrates `spring-security-oauth2-client` and `spring-security-oaut
 ** *IMPORTANT:* Make sure to modify your `/etc/hosts` file to avoid problems with session cookie overwrites between `client` and `authorizationserver`. Simply add the entry `127.0.0.1	auth-server`
 * Run Resource Server -> `./gradlew -b samples/boot/oauth2-integration/resourceserver/spring-security-samples-boot-oauth2-integrated-resourceserver.gradle bootRun`
 * Run Client -> `./gradlew -b samples/boot/oauth2-integration/client/spring-security-samples-boot-oauth2-integrated-client.gradle bootRun`
-* Go to `http://localhost:8080`
+* Go to `http://127.0.0.1:8080`

--- a/samples/boot/oauth2-integration/authorizationserver/spring-security-samples-boot-oauth2-integrated-authorizationserver.gradle
+++ b/samples/boot/oauth2-integration/authorizationserver/spring-security-samples-boot-oauth2-integrated-authorizationserver.gradle
@@ -4,4 +4,7 @@ dependencies {
 	compile 'org.springframework.boot:spring-boot-starter-web'
 	compile 'org.springframework.boot:spring-boot-starter-security'
 	compile project(':spring-security-oauth2-authorization-server')
+
+	testCompile 'org.springframework.boot:spring-boot-starter-test'
+	testCompile 'net.sourceforge.htmlunit:htmlunit'
 }

--- a/samples/boot/oauth2-integration/authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
+++ b/samples/boot/oauth2-integration/authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
@@ -25,8 +25,6 @@ import sample.jose.Jwks;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.security.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.OidcScopes;
@@ -40,7 +38,6 @@ import org.springframework.security.oauth2.server.authorization.config.ProviderS
  * @since 0.0.1
  */
 @Configuration(proxyBeanMethods = false)
-@Import(OAuth2AuthorizationServerConfiguration.class)
 public class AuthorizationServerConfig {
 
 	// @formatter:off
@@ -53,8 +50,8 @@ public class AuthorizationServerConfig {
 				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
 				.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
 				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-				.redirectUri("http://localhost:8080/login/oauth2/code/messaging-client-oidc")
-				.redirectUri("http://localhost:8080/authorized")
+				.redirectUri("http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc")
+				.redirectUri("http://127.0.0.1:8080/authorized")
 				.scope(OidcScopes.OPENID)
 				.scope("message.read")
 				.scope("message.write")

--- a/samples/boot/oauth2-integration/authorizationserver/src/main/java/sample/config/DefaultSecurityConfig.java
+++ b/samples/boot/oauth2-integration/authorizationserver/src/main/java/sample/config/DefaultSecurityConfig.java
@@ -18,13 +18,12 @@ package sample.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.security.config.Customizer.withDefaults;
 
 /**
  * @author Joe Grandja
@@ -36,11 +35,14 @@ public class DefaultSecurityConfig {
 	// formatter:off
 	@Bean
 	SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+		OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
 		http
-			.authorizeRequests(authorizeRequests ->
-				authorizeRequests.anyRequest().authenticated()
-			)
-			.formLogin(withDefaults());
+				.authorizeRequests()
+					.antMatchers("/favicon.ico").permitAll()
+					.anyRequest().authenticated()
+					.and()
+				.formLogin();
+
 		return http.build();
 	}
 	// formatter:on

--- a/samples/boot/oauth2-integration/authorizationserver/src/test/java/sample/OAuth2AuthorizationServerApplicationTests.java
+++ b/samples/boot/oauth2-integration/authorizationserver/src/test/java/sample/OAuth2AuthorizationServerApplicationTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for sample Authorization Server.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class OAuth2AuthorizationServerApplicationTests {
+
+	@Autowired
+	private WebClient webClient;
+
+	private final String REDIRECT_URI = "http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc";
+	private final String AUTHORIZE_REQUEST = UriComponentsBuilder
+			.fromPath("/oauth2/authorize")
+			.queryParam("response_type", "code")
+			.queryParam("client_id", "messaging-client")
+			.queryParam("scope", "openid")
+			.queryParam("state", "some-state")
+			.queryParam("redirect_uri", REDIRECT_URI)
+			.toUriString();
+
+	@Before
+	public void setUp() {
+		this.webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
+		this.webClient.getOptions().setRedirectEnabled(true);
+		this.webClient.getCookieManager().clearCookies(); // log out
+	}
+
+	@Test
+	public void whenLoginSuccessfulThenDisplayNotFoundError() throws IOException {
+		HtmlPage page = this.webClient.getPage("/");
+
+		assertLoginPage(page);
+
+		this.webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+		WebResponse signInResponse = signIn(page, "user1", "password").getWebResponse();
+		assertThat(signInResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()); // there is not "default" index page
+	}
+
+
+	@Test
+	public void whenLoginFailsThenDisplayBadCredentials() throws IOException {
+		HtmlPage page = this.webClient.getPage("/");
+
+		HtmlPage loginErrorPage = signIn(page, "user1", "wrong-password");
+
+		HtmlElement alert = loginErrorPage.querySelector("div[role=\"alert\"]");
+		assertThat(alert).isNotNull();
+		assertThat(alert.getTextContent()).isEqualTo("Bad credentials");
+	}
+
+	@Test
+	public void whenRequestingATokenThenRedirectsToLogin() throws IOException {
+		HtmlPage page = this.webClient.getPage(this.AUTHORIZE_REQUEST);
+
+		assertLoginPage(page);
+	}
+
+	@Test
+	public void whenLoggingInAndRequestingTokenTheRedirectsToClientApplication() throws IOException {
+		// Log in
+		this.webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+		this.webClient.getOptions().setRedirectEnabled(false);
+		signIn(this.webClient.getPage("/login"), "user1", "password");
+
+		// Request token
+		WebResponse response = this.webClient.getPage(this.AUTHORIZE_REQUEST).getWebResponse();
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.MOVED_PERMANENTLY.value());
+		String location = response.getResponseHeaderValue("location");
+		assertThat(location).startsWith(REDIRECT_URI);
+		assertThat(location).contains("code=");
+	}
+
+	private <P extends Page> P signIn(HtmlPage page, String username, String password) throws IOException {
+		HtmlInput usernameInput = page.querySelector("input[name=\"username\"]");
+		HtmlInput passwordInput = page.querySelector("input[name=\"password\"]");
+		HtmlButton signInButton = page.querySelector("button");
+
+		usernameInput.type(username);
+		passwordInput.type(password);
+		return signInButton.click();
+	}
+
+	private void assertLoginPage(HtmlPage page) {
+		assertThat(page.getUrl().toString()).endsWith("/login");
+
+		HtmlInput usernameInput = page.querySelector("input[name=\"username\"]");
+		HtmlInput passwordInput = page.querySelector("input[name=\"password\"]");
+		HtmlButton signInButton = page.querySelector("button");
+
+		assertThat(usernameInput).isNotNull();
+		assertThat(passwordInput).isNotNull();
+		assertThat(signInButton.getTextContent()).isEqualTo("Sign in");
+	}
+}


### PR DESCRIPTION
Fixes regressions introduced by latest commits:
- `localhost` is disallowed in redirect_uris as per OAuth 2.1, we are now using 127.0.0.1 instead
- Merged the filter chain for spring-authorization-server and the sample app.
- Added simple "integration" tests to avoid regressions.

This is not merge-ready yet.

Notes:
- Trying to navigate to `http://auth-server:9000/oauth2/authorize?response_type=code&client_id=messaging-client&scope=openid&state=SOME_STATE=&redirect_uri=http://localhost:8080/login/oauth2/code/messaging-client-oidc` and logging in gives an error HTTP 999 (??) instead of 400
- `.antMatcher("/error").permitAll()` gives the 400 error back, not sure why...