### PR TITLE
Include the remote address in authentication details

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/ClientSecretBasicAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/ClientSecretBasicAuthenticationConverter.java
@@ -16,6 +16,7 @@
 package org.springframework.security.oauth2.server.authorization.web;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -23,6 +24,7 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -44,6 +46,8 @@ import java.util.Map;
  * @see OAuth2ClientAuthenticationFilter
  */
 public class ClientSecretBasicAuthenticationConverter implements AuthenticationConverter {
+
+	private static final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
 	@Override
 	public Authentication convert(HttpServletRequest request) {
@@ -86,8 +90,10 @@ public class ClientSecretBasicAuthenticationConverter implements AuthenticationC
 			throw new OAuth2AuthenticationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST), ex);
 		}
 
-		return new OAuth2ClientAuthenticationToken(clientID, clientSecret, ClientAuthenticationMethod.BASIC,
+		OAuth2ClientAuthenticationToken oAuth2ClientAuthenticationToken = new OAuth2ClientAuthenticationToken(clientID, clientSecret, ClientAuthenticationMethod.BASIC,
 				extractAdditionalParameters(request));
+		oAuth2ClientAuthenticationToken.setDetails(authenticationDetailsSource.buildDetails(request));
+		return oAuth2ClientAuthenticationToken;
 	}
 
 	private static Map<String, Object> extractAdditionalParameters(HttpServletRequest request) {

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/ClientSecretPostAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/ClientSecretPostAuthenticationConverter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization.web;
 
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -23,6 +24,7 @@ import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
@@ -42,6 +44,8 @@ import java.util.Map;
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-2.3.1">Section 2.3.1 Client Password</a>
  */
 public class ClientSecretPostAuthenticationConverter implements AuthenticationConverter {
+
+	private static final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
 	@Override
 	public Authentication convert(HttpServletRequest request) {
@@ -67,8 +71,10 @@ public class ClientSecretPostAuthenticationConverter implements AuthenticationCo
 			throw new OAuth2AuthenticationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST));
 		}
 
-		return new OAuth2ClientAuthenticationToken(clientId, clientSecret, ClientAuthenticationMethod.POST,
+		OAuth2ClientAuthenticationToken oAuth2ClientAuthenticationToken = new OAuth2ClientAuthenticationToken(clientId, clientSecret, ClientAuthenticationMethod.POST,
 				extractAdditionalParameters(request));
+		oAuth2ClientAuthenticationToken.setDetails(authenticationDetailsSource.buildDetails(request));
+		return oAuth2ClientAuthenticationToken;
 	}
 
 	private static Map<String, Object> extractAdditionalParameters(HttpServletRequest request) {

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilter.java
@@ -34,6 +34,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -55,6 +56,7 @@ import org.springframework.security.oauth2.server.authorization.authentication.O
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2RefreshTokenAuthenticationProvider;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2RefreshTokenAuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
@@ -202,6 +204,8 @@ public class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 
 	private static class AuthorizationCodeAuthenticationConverter implements AuthenticationConverter {
 
+		private static final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
+
 		@Override
 		public Authentication convert(HttpServletRequest request) {
 			// grant_type (REQUIRED)
@@ -240,12 +244,16 @@ public class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 					.collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(0)));
 			// @formatter:on
 
-			return new OAuth2AuthorizationCodeAuthenticationToken(
+			OAuth2AuthorizationCodeAuthenticationToken oAuth2AuthorizationCodeAuthenticationToken = new OAuth2AuthorizationCodeAuthenticationToken(
 					code, clientPrincipal, redirectUri, additionalParameters);
+			oAuth2AuthorizationCodeAuthenticationToken.setDetails(authenticationDetailsSource.buildDetails(request));
+			return oAuth2AuthorizationCodeAuthenticationToken;
 		}
 	}
 
 	private static class RefreshTokenAuthenticationConverter implements AuthenticationConverter {
+
+		private static final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
 		@Override
 		public Authentication convert(HttpServletRequest request) {
@@ -288,12 +296,16 @@ public class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 					.collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(0)));
 			// @formatter:on
 
-			return new OAuth2RefreshTokenAuthenticationToken(
+			OAuth2RefreshTokenAuthenticationToken oAuth2RefreshTokenAuthenticationToken = new OAuth2RefreshTokenAuthenticationToken(
 					refreshToken, clientPrincipal, requestedScopes, additionalParameters);
+			oAuth2RefreshTokenAuthenticationToken.setDetails(authenticationDetailsSource.buildDetails(request));
+			return oAuth2RefreshTokenAuthenticationToken;
 		}
 	}
 
 	private static class ClientCredentialsAuthenticationConverter implements AuthenticationConverter {
+
+		private static final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
 		@Override
 		public Authentication convert(HttpServletRequest request) {
@@ -328,8 +340,10 @@ public class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 					.collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(0)));
 			// @formatter:on
 
-			return new OAuth2ClientCredentialsAuthenticationToken(
+			OAuth2ClientCredentialsAuthenticationToken oAuth2ClientCredentialsAuthenticationToken = new OAuth2ClientCredentialsAuthenticationToken(
 					clientPrincipal, requestedScopes, additionalParameters);
+			oAuth2ClientCredentialsAuthenticationToken.setDetails(authenticationDetailsSource.buildDetails(request));
+			return oAuth2ClientCredentialsAuthenticationToken;
 		}
 	}
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/PublicClientAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/PublicClientAuthenticationConverter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization.web;
 
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -23,6 +24,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
@@ -41,6 +43,8 @@ import java.util.HashMap;
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7636">Proof Key for Code Exchange by OAuth Public Clients</a>
  */
 public class PublicClientAuthenticationConverter implements AuthenticationConverter {
+
+	private static final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
 	@Override
 	public Authentication convert(HttpServletRequest request) {
@@ -64,7 +68,9 @@ public class PublicClientAuthenticationConverter implements AuthenticationConver
 
 		parameters.remove(OAuth2ParameterNames.CLIENT_ID);
 
-		return new OAuth2ClientAuthenticationToken(
+		OAuth2ClientAuthenticationToken oAuth2ClientAuthenticationToken = new OAuth2ClientAuthenticationToken(
 				clientId, new HashMap<>(parameters.toSingleValueMap()));
+		oAuth2ClientAuthenticationToken.setDetails(authenticationDetailsSource.buildDetails(request));
+		return oAuth2ClientAuthenticationToken;
 	}
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/ClientSecretPostAuthenticationConverterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/ClientSecretPostAuthenticationConverterTests.java
@@ -25,10 +25,12 @@ import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 /**
  * Tests for {@link ClientSecretPostAuthenticationConverter}.
@@ -103,6 +105,19 @@ public class ClientSecretPostAuthenticationConverterTests {
 						entry(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.AUTHORIZATION_CODE.getValue()),
 						entry(OAuth2ParameterNames.CODE, "code"),
 						entry(PkceParameterNames.CODE_VERIFIER, "code-verifier-1"));
+	}
+
+	@Test
+	public void convertIncludesWebAuthenticationDetailsAsAuthenticationDetails() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(OAuth2ParameterNames.CLIENT_ID, "client-1");
+		request.addParameter(OAuth2ParameterNames.CLIENT_SECRET, "client-secret");
+		request.setRemoteAddr("remote address");
+		OAuth2ClientAuthenticationToken authentication = (OAuth2ClientAuthenticationToken) this.converter.convert(request);
+		assertThat(authentication.getDetails())
+				.asInstanceOf(type(WebAuthenticationDetails.class))
+				.extracting(WebAuthenticationDetails::getRemoteAddress)
+				.isEqualTo("remote address");
 	}
 
 	private static MockHttpServletRequest createPkceTokenRequest() {

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilterTests.java
@@ -57,11 +57,13 @@ import org.springframework.security.oauth2.server.authorization.authentication.O
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2RefreshTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.TestRegisteredClients;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -236,6 +238,10 @@ public class OAuth2TokenEndpointFilterTests {
 				request.getParameter(OAuth2ParameterNames.REDIRECT_URI));
 		assertThat(authorizationCodeAuthentication.getAdditionalParameters())
 				.containsExactly(entry("custom-param-1", "custom-value-1"));
+		assertThat(authorizationCodeAuthentication.getDetails())
+				.asInstanceOf(type(WebAuthenticationDetails.class))
+				.extracting(WebAuthenticationDetails::getRemoteAddress)
+				.isEqualTo("remote address for authorization code token request");
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
 		OAuth2AccessTokenResponse accessTokenResponse = readAccessTokenResponse(response);
@@ -298,6 +304,10 @@ public class OAuth2TokenEndpointFilterTests {
 		assertThat(clientCredentialsAuthentication.getScopes()).isEqualTo(registeredClient.getScopes());
 		assertThat(clientCredentialsAuthentication.getAdditionalParameters())
 				.containsExactly(entry("custom-param-1", "custom-value-1"));
+		assertThat(clientCredentialsAuthentication.getDetails())
+				.asInstanceOf(type(WebAuthenticationDetails.class))
+				.extracting(WebAuthenticationDetails::getRemoteAddress)
+				.isEqualTo("remote address for client credentials token request");
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
 		OAuth2AccessTokenResponse accessTokenResponse = readAccessTokenResponse(response);
@@ -380,6 +390,10 @@ public class OAuth2TokenEndpointFilterTests {
 		assertThat(refreshTokenAuthenticationToken.getScopes()).isEqualTo(registeredClient.getScopes());
 		assertThat(refreshTokenAuthenticationToken.getAdditionalParameters())
 				.containsExactly(entry("custom-param-1", "custom-value-1"));
+		assertThat(refreshTokenAuthenticationToken.getDetails())
+				.asInstanceOf(type(WebAuthenticationDetails.class))
+				.extracting(WebAuthenticationDetails::getRemoteAddress)
+				.isEqualTo("remote address for refresh token request");
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
 		OAuth2AccessTokenResponse accessTokenResponse = readAccessTokenResponse(response);
@@ -439,6 +453,8 @@ public class OAuth2TokenEndpointFilterTests {
 		request.addParameter(OAuth2ParameterNames.CLIENT_ID, registeredClient.getClientId());
 		request.addParameter("custom-param-1", "custom-value-1");
 
+		request.setRemoteAddr("remote address for authorization code token request");
+
 		return request;
 	}
 
@@ -451,6 +467,8 @@ public class OAuth2TokenEndpointFilterTests {
 		request.addParameter(OAuth2ParameterNames.SCOPE,
 				StringUtils.collectionToDelimitedString(registeredClient.getScopes(), " "));
 		request.addParameter("custom-param-1", "custom-value-1");
+
+		request.setRemoteAddr("remote address for client credentials token request");
 
 		return request;
 	}
@@ -465,6 +483,8 @@ public class OAuth2TokenEndpointFilterTests {
 		request.addParameter(OAuth2ParameterNames.SCOPE,
 				StringUtils.collectionToDelimitedString(registeredClient.getScopes(), " "));
 		request.addParameter("custom-param-1", "custom-value-1");
+
+		request.setRemoteAddr("remote address for refresh token request");
 
 		return request;
 	}

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/PublicClientAuthenticationConverterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/PublicClientAuthenticationConverterTests.java
@@ -25,10 +25,12 @@ import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 /**
  * Tests for {@link PublicClientAuthenticationConverter}.
@@ -89,6 +91,17 @@ public class PublicClientAuthenticationConverterTests {
 						entry(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.AUTHORIZATION_CODE.getValue()),
 						entry(OAuth2ParameterNames.CODE, "code"),
 						entry(PkceParameterNames.CODE_VERIFIER, "code-verifier-1"));
+	}
+
+	@Test
+	public void convertIncludesWebAuthenticationDetailsAsAuthenticationDetails() {
+		MockHttpServletRequest request = createPkceTokenRequest();
+		request.setRemoteAddr("remote address of the public client");
+		OAuth2ClientAuthenticationToken authentication = (OAuth2ClientAuthenticationToken) this.converter.convert(request);
+		assertThat(authentication.getDetails())
+				.asInstanceOf(type(WebAuthenticationDetails.class))
+				.extracting(WebAuthenticationDetails::getRemoteAddress)
+				.isEqualTo("remote address of the public client");
 	}
 
 	private static MockHttpServletRequest createPkceTokenRequest() {


### PR DESCRIPTION
We'd like to log the IP address whenever an authN/authZ event happens in Spring Auth Server, such as:

* Client Credentials token issued
* Client authN failure
* ID token issued
* etc

For non-OAuth2/OIDC scenarios such as user login, we rely on the `Authentication::getDetails()` method to return an instance of `WebAuthenticationDetails` that includes the user's remote IP address.

The changes below modifies each `AuthenticationConverter` to add `WebAuthenticationDetails` to the generated `Authentication` object, and modifies each `AuthenticationProvider` to pass through the `WebAuthenticationDetails` to the new `Authentication` object.

If this approach seems reasonable, I'll update this PR with tests.